### PR TITLE
Halftime Scores Display Fix

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-result.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-result.php
@@ -83,7 +83,7 @@ class WPCM_Meta_Box_Match_Result {
 		<div id="results-table">
 
 		<?php
-		if( get_option( 'wpcm_results_box_scores' ) == 'yes' ) { ?>
+		if( get_option( 'wpcm_match_box_scores' ) == 'yes' ) { ?>
 
 			<table class="box-scores-table">
 				<thead>
@@ -94,7 +94,7 @@ class WPCM_Meta_Box_Match_Result {
 					</tr>
 				</thead>
 				<tbody>
-							
+
 					<?php
 					if( $sport == 'volleyball' ) :
 
@@ -233,7 +233,7 @@ class WPCM_Meta_Box_Match_Result {
 				} else { ?>
 
 					<tbody>
-						
+
 						<?php do_action('wpclubmanager_admin_results_table', $post->ID ); ?>
 						<tr>
 							<th align="right"><?php _e( 'Final Score', 'wp-club-manager' ); ?></th>
@@ -255,7 +255,7 @@ class WPCM_Meta_Box_Match_Result {
 				<div class="wpcm-results-outcome">
 
 					<?php
-					wpclubmanager_wp_select( array( 
+					wpclubmanager_wp_select( array(
 						'id' => 'cricket_outcome_0',
 						'value' => $wpcm_cricket_outcome[0],
 						'class' => 'chosen_select_outcome',
@@ -273,7 +273,7 @@ class WPCM_Meta_Box_Match_Result {
 					<input type="number" class="wpcm_cricket_outcome" name="cricket_outcome_1" min="0" max="999" value="<?php echo $wpcm_cricket_outcome[1]; ?>" />
 
 					<?php
-					wpclubmanager_wp_select( array( 
+					wpclubmanager_wp_select( array(
 						'id' => 'cricket_outcome_2',
 						'value' => $wpcm_cricket_outcome[2],
 						'class' => 'chosen_select_outcome',
@@ -337,7 +337,7 @@ class WPCM_Meta_Box_Match_Result {
 			<?php } ?>
 
 			<?php if ( $sport == 'hockey' || $sport == 'handball' ) { ?>
-				
+
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_shootout" id="wpcm_shootout" value="1" <?php checked( true, $shootout ); ?> />
@@ -348,7 +348,7 @@ class WPCM_Meta_Box_Match_Result {
 			<?php } ?>
 
 			<?php if ( $sport == 'soccer' ) { ?>
-				
+
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_overtime" id="wpcm_overtime" value="1" <?php checked( true, $overtime ); ?> />

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WP Club Manager - WordPress Sports Club Plugin===
-Contributors: clubpress, leonterry
-Tags: club, teams, sports, sports club, club management, club website, league management, league tables, team rosters, fixtures, results 
+Contributors: clubpress, leonterry, daveyjake
+Tags: club, teams, sports, sports club, club management, club website, league management, league tables, team rosters, fixtures, results
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ZGGZXX2EQTZ9E
 Requires at least: 4.7
 Tested up to: 5.3
@@ -16,7 +16,7 @@ WP Club Manager is a sports plugin used to create and manage a club or league we
 
 = Endorsed by USA Rugby =
 
-> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports team who wants a better website!*"  
+> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports team who wants a better website!*"
 Davey Jacobson, *Digital Platform Developer*, [USA Rugby](http://usarugby.org)
 
 = Features Include =
@@ -249,7 +249,7 @@ You can help improve this plugin by reporting any bugs or contributing to the so
 
 = 2.0.7 - 08/04/2019
 
-* Fix - Version bump to fix synch SVN 
+* Fix - Version bump to fix synch SVN
 
 = 2.0.6 - 05/04/2019
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,8 +16,8 @@ WP Club Manager is a sports plugin used to create and manage a club or league we
 
 = Endorsed by USA Rugby =
 
-> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports team who wants a better website!*"
-Davey Jacobson, *Digital Platform Developer*, [USA Rugby](http://usarugby.org)
+> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports teams that want a better website!*"
+Davey Jacobson, *Information Systems Developer*, [USA Rugby](https://www.usa.rugby/)
 
 = Features Include =
 


### PR DESCRIPTION
Inside the `WPCM_Meta_Box_Match_Result` class, there was a conditional check against `get_option( 'wpcm_results_box_scores' )`.  That key did not exist inside the `wp_options` table.  I changed it to check against `get_option( 'wpcm_match_box_scores' )`.  The option to display halftime score is now functioning as expected.