### PR TITLE
ACF Compatibility

### DIFF
--- a/includes/admin/class-wpcm-admin-assets.php
+++ b/includes/admin/class-wpcm-admin-assets.php
@@ -93,7 +93,7 @@ class WPCM_Admin_Assets {
 
 		wp_register_script( 'wpclubmanager-admin-locationpicker', WPCM()->plugin_url() . '/assets/js/admin/locationpicker.js', array( 'jquery', 'google-maps', 'jquery-locationpicker' ), WPCM_VERSION, true );
 
-		if ( is_plugin_active( 'advanced-custom-fields-pro/acf.php' ) ) {
+		if ( ! wp_script_is( 'acf-timepicker' ) ) {
 			wp_register_script( 'jquery-timepicker', WPCM()->plugin_url() . '/assets/js/jquery.timepicker' .$suffix . '.js', array( 'jquery' ), '1.11.13', true );
 		}
 

--- a/includes/admin/class-wpcm-admin-assets.php
+++ b/includes/admin/class-wpcm-admin-assets.php
@@ -18,7 +18,7 @@ class WPCM_Admin_Assets {
 	 * Hook in tabs.
 	 */
 	public function __construct() {
-
+		
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 	}
@@ -78,7 +78,7 @@ class WPCM_Admin_Assets {
 
 		// Register scripts
 		wp_register_script( 'wpclubmanager_admin', WPCM()->plugin_url() . '/assets/js/admin/wpclubmanager_admin' . $suffix . '.js', array( 'jquery', 'jquery-ui-widget', 'jquery-ui-core', 'jquery-ui-sortable' ), WPCM_VERSION );
-
+		
 		wp_register_script( 'ajax-chosen', WPCM()->plugin_url() . '/assets/js/jquery-chosen/ajax-chosen.jquery' . $suffix . '.js', array('jquery', 'chosen'), WPCM_VERSION );
 
 		wp_register_script( 'order-chosen', WPCM()->plugin_url() . '/assets/js/jquery-chosen/chosen.order.jquery' . $suffix . '.js', array('jquery'), '1.2.1' );
@@ -88,14 +88,18 @@ class WPCM_Admin_Assets {
 		wp_register_script('wpcm-tax-order', WPCM()->plugin_url() . '/assets/js/admin/wpclubmanager_tax_order' . $suffix . '.js', array('jquery-ui-core', 'jquery-ui-sortable'), WPCM_VERSION );
 
 		wp_register_script( 'google-maps', '//maps.googleapis.com/maps/api/js?key=' . $api_key . '&libraries=places' );
-
+		
 		wp_register_script( 'jquery-locationpicker', WPCM()->plugin_url() . '/assets/js/locationpicker.jquery.js', array( 'jquery', 'google-maps' ), '0.1.16', true );
 
 		wp_register_script( 'wpclubmanager-admin-locationpicker', WPCM()->plugin_url() . '/assets/js/admin/locationpicker.js', array( 'jquery', 'google-maps', 'jquery-locationpicker' ), WPCM_VERSION, true );
 
+<<<<<<< HEAD
 		if ( ! wp_script_is( 'acf-timepicker' ) ) {
 			wp_register_script( 'jquery-timepicker', WPCM()->plugin_url() . '/assets/js/jquery.timepicker' .$suffix . '.js', array( 'jquery' ), '1.11.13', true );
 		}
+=======
+		wp_register_script( 'jquery-timepicker', WPCM()->plugin_url() . '/assets/js/jquery.timepicker' .$suffix . '.js', array( 'jquery' ), '1.11.13', true );
+>>>>>>> parent of c18891b... ACF Compatibility
 
 		wp_register_script( 'wpclubmanager-admin-combify', WPCM()->plugin_url() . '/assets/js/admin/combify' .$suffix . '.js', array( 'jquery' ), WPCM_VERSION, true );
 

--- a/includes/admin/class-wpcm-admin-assets.php
+++ b/includes/admin/class-wpcm-admin-assets.php
@@ -18,7 +18,7 @@ class WPCM_Admin_Assets {
 	 * Hook in tabs.
 	 */
 	public function __construct() {
-		
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 	}
@@ -78,7 +78,7 @@ class WPCM_Admin_Assets {
 
 		// Register scripts
 		wp_register_script( 'wpclubmanager_admin', WPCM()->plugin_url() . '/assets/js/admin/wpclubmanager_admin' . $suffix . '.js', array( 'jquery', 'jquery-ui-widget', 'jquery-ui-core', 'jquery-ui-sortable' ), WPCM_VERSION );
-		
+
 		wp_register_script( 'ajax-chosen', WPCM()->plugin_url() . '/assets/js/jquery-chosen/ajax-chosen.jquery' . $suffix . '.js', array('jquery', 'chosen'), WPCM_VERSION );
 
 		wp_register_script( 'order-chosen', WPCM()->plugin_url() . '/assets/js/jquery-chosen/chosen.order.jquery' . $suffix . '.js', array('jquery'), '1.2.1' );
@@ -88,18 +88,14 @@ class WPCM_Admin_Assets {
 		wp_register_script('wpcm-tax-order', WPCM()->plugin_url() . '/assets/js/admin/wpclubmanager_tax_order' . $suffix . '.js', array('jquery-ui-core', 'jquery-ui-sortable'), WPCM_VERSION );
 
 		wp_register_script( 'google-maps', '//maps.googleapis.com/maps/api/js?key=' . $api_key . '&libraries=places' );
-		
+
 		wp_register_script( 'jquery-locationpicker', WPCM()->plugin_url() . '/assets/js/locationpicker.jquery.js', array( 'jquery', 'google-maps' ), '0.1.16', true );
 
 		wp_register_script( 'wpclubmanager-admin-locationpicker', WPCM()->plugin_url() . '/assets/js/admin/locationpicker.js', array( 'jquery', 'google-maps', 'jquery-locationpicker' ), WPCM_VERSION, true );
 
-<<<<<<< HEAD
 		if ( ! wp_script_is( 'acf-timepicker' ) ) {
 			wp_register_script( 'jquery-timepicker', WPCM()->plugin_url() . '/assets/js/jquery.timepicker' .$suffix . '.js', array( 'jquery' ), '1.11.13', true );
 		}
-=======
-		wp_register_script( 'jquery-timepicker', WPCM()->plugin_url() . '/assets/js/jquery.timepicker' .$suffix . '.js', array( 'jquery' ), '1.11.13', true );
->>>>>>> parent of c18891b... ACF Compatibility
 
 		wp_register_script( 'wpclubmanager-admin-combify', WPCM()->plugin_url() . '/assets/js/admin/combify' .$suffix . '.js', array( 'jquery' ), WPCM_VERSION, true );
 

--- a/includes/admin/class-wpcm-admin-assets.php
+++ b/includes/admin/class-wpcm-admin-assets.php
@@ -18,7 +18,7 @@ class WPCM_Admin_Assets {
 	 * Hook in tabs.
 	 */
 	public function __construct() {
-		
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 	}
@@ -78,7 +78,7 @@ class WPCM_Admin_Assets {
 
 		// Register scripts
 		wp_register_script( 'wpclubmanager_admin', WPCM()->plugin_url() . '/assets/js/admin/wpclubmanager_admin' . $suffix . '.js', array( 'jquery', 'jquery-ui-widget', 'jquery-ui-core', 'jquery-ui-sortable' ), WPCM_VERSION );
-		
+
 		wp_register_script( 'ajax-chosen', WPCM()->plugin_url() . '/assets/js/jquery-chosen/ajax-chosen.jquery' . $suffix . '.js', array('jquery', 'chosen'), WPCM_VERSION );
 
 		wp_register_script( 'order-chosen', WPCM()->plugin_url() . '/assets/js/jquery-chosen/chosen.order.jquery' . $suffix . '.js', array('jquery'), '1.2.1' );
@@ -88,12 +88,14 @@ class WPCM_Admin_Assets {
 		wp_register_script('wpcm-tax-order', WPCM()->plugin_url() . '/assets/js/admin/wpclubmanager_tax_order' . $suffix . '.js', array('jquery-ui-core', 'jquery-ui-sortable'), WPCM_VERSION );
 
 		wp_register_script( 'google-maps', '//maps.googleapis.com/maps/api/js?key=' . $api_key . '&libraries=places' );
-		
+
 		wp_register_script( 'jquery-locationpicker', WPCM()->plugin_url() . '/assets/js/locationpicker.jquery.js', array( 'jquery', 'google-maps' ), '0.1.16', true );
 
 		wp_register_script( 'wpclubmanager-admin-locationpicker', WPCM()->plugin_url() . '/assets/js/admin/locationpicker.js', array( 'jquery', 'google-maps', 'jquery-locationpicker' ), WPCM_VERSION, true );
 
-		wp_register_script( 'jquery-timepicker', WPCM()->plugin_url() . '/assets/js/jquery.timepicker' .$suffix . '.js', array( 'jquery' ), '1.11.13', true );
+		if ( is_plugin_active( 'advanced-custom-fields-pro/acf.php' ) ) {
+			wp_register_script( 'jquery-timepicker', WPCM()->plugin_url() . '/assets/js/jquery.timepicker' .$suffix . '.js', array( 'jquery' ), '1.11.13', true );
+		}
 
 		wp_register_script( 'wpclubmanager-admin-combify', WPCM()->plugin_url() . '/assets/js/admin/combify' .$suffix . '.js', array( 'jquery' ), WPCM_VERSION, true );
 

--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-result.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-result.php
@@ -94,7 +94,7 @@ class WPCM_Meta_Box_Match_Result {
 					</tr>
 				</thead>
 				<tbody>
-							
+
 					<?php
 					if( $sport == 'volleyball' ) :
 
@@ -194,7 +194,7 @@ class WPCM_Meta_Box_Match_Result {
 		} ?>
 			<table class="final-score-table">
 				<?php
-				if( get_option( 'wpcm_results_box_scores' ) != 'yes' ) { ?>
+				if( get_option( 'wpcm_match_box_scores' ) != 'yes' ) { ?>
 					<thead>
 						<tr>
 							<td>&nbsp;</td>
@@ -233,7 +233,7 @@ class WPCM_Meta_Box_Match_Result {
 				} else { ?>
 
 					<tbody>
-						
+
 						<?php do_action('wpclubmanager_admin_results_table', $post->ID ); ?>
 						<tr>
 							<th align="right"><?php _e( 'Final Score', 'wp-club-manager' ); ?></th>
@@ -255,7 +255,7 @@ class WPCM_Meta_Box_Match_Result {
 				<div class="wpcm-results-outcome">
 
 					<?php
-					wpclubmanager_wp_select( array( 
+					wpclubmanager_wp_select( array(
 						'id' => 'cricket_outcome_0',
 						'value' => $wpcm_cricket_outcome[0],
 						'class' => 'chosen_select_outcome',
@@ -273,7 +273,7 @@ class WPCM_Meta_Box_Match_Result {
 					<input type="number" class="wpcm_cricket_outcome" name="cricket_outcome_1" min="0" max="999" value="<?php echo $wpcm_cricket_outcome[1]; ?>" />
 
 					<?php
-					wpclubmanager_wp_select( array( 
+					wpclubmanager_wp_select( array(
 						'id' => 'cricket_outcome_2',
 						'value' => $wpcm_cricket_outcome[2],
 						'class' => 'chosen_select_outcome',
@@ -337,7 +337,7 @@ class WPCM_Meta_Box_Match_Result {
 			<?php } ?>
 
 			<?php if ( $sport == 'hockey' || $sport == 'handball' ) { ?>
-				
+
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_shootout" id="wpcm_shootout" value="1" <?php checked( true, $shootout ); ?> />
@@ -348,7 +348,7 @@ class WPCM_Meta_Box_Match_Result {
 			<?php } ?>
 
 			<?php if ( $sport == 'soccer' ) { ?>
-				
+
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_overtime" id="wpcm_overtime" value="1" <?php checked( true, $overtime ); ?> />

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ WP Club Manager is a sports plugin used to create and manage a club or league we
 
 = Endorsed by USA Rugby =
 
-> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports teams that wants a better website!*"
+> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports teams that want a better website!*"
 Davey Jacobson, *Information Systems Developer*, [USA Rugby](https://www.usa.rugby)
 
 = Features Include =

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WP Club Manager - WordPress Sports Club Plugin===
-Contributors: clubpress, leonterry
-Tags: club, teams, sports, sports club, club management, club website, league management, league tables, team rosters, fixtures, results 
+Contributors: clubpress, leonterry, daveyjake
+Tags: club, teams, sports, sports club, club management, club website, league management, league tables, team rosters, fixtures, results
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ZGGZXX2EQTZ9E
 Requires at least: 4.7
 Tested up to: 5.3
@@ -16,7 +16,7 @@ WP Club Manager is a sports plugin used to create and manage a club or league we
 
 = Endorsed by USA Rugby =
 
-> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports team who wants a better website!*"  
+> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports team who wants a better website!*"
 Davey Jacobson, *Digital Platform Developer*, [USA Rugby](http://usarugby.org)
 
 = Features Include =
@@ -249,7 +249,7 @@ You can help improve this plugin by reporting any bugs or contributing to the so
 
 = 2.0.7 - 08/04/2019
 
-* Fix - Version bump to fix synch SVN 
+* Fix - Version bump to fix synch SVN
 
 = 2.0.6 - 05/04/2019
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,8 +16,8 @@ WP Club Manager is a sports plugin used to create and manage a club or league we
 
 = Endorsed by USA Rugby =
 
-> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports team who wants a better website!*"
-Davey Jacobson, *Digital Platform Developer*, [USA Rugby](http://usarugby.org)
+> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports teams that wants a better website!*"
+Davey Jacobson, *Information Systems Developer*, [USA Rugby](https://www.usa.rugby)
 
 = Features Include =
 


### PR DESCRIPTION
Hey mate,

Can't figure out how to not include the previous PRs (from 11 Feb).  The important PR here is [`295c983`](https://github.com/ClubPress/wp-club-manager/commit/295c98370674fd48146a7653a4ab2c369d79061b); it adds a negative `wp_script_is` check for ACF's version of jQuery Timepicker.

Currently, if ACF and WPCM are installed together, this is what happens when setting up matches:

<img src="https://user-images.githubusercontent.com/826532/75180607-c7f83780-56f9-11ea-8e02-7ad27ccb293c.png" width="100%" />

If `wp_script_is` returns true, WPCM's version gets used.  If not, ACF's version gets used.