### PR TITLE
Fix: resolve all PHPCS errors

### DIFF
--- a/i18n.php
+++ b/i18n.php
@@ -7,5 +7,8 @@
  * This stub prevents the fatal error. We don't use Gherkin/BDD tests.
  *
  * @see https://github.com/Codeception/Codeception/issues/6607
+ *
+ * @package WPClubManager
  */
+
 return require __DIR__ . '/vendor/behat/gherkin/i18n.php';

--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -30,7 +30,7 @@ class WPCM_Admin_Dashboard {
 				<?php
 				if ( is_club_mode() ) {
 					$default_club = get_default_club();
-					$team      = filter_input( INPUT_POST, 'team_select', FILTER_UNSAFE_RAW );
+					$team         = filter_input( INPUT_POST, 'team_select', FILTER_UNSAFE_RAW );
 					if ( $team ) {
 						$term      = get_term( $team, 'wpcm_team' );
 						$team_name = $term->name;
@@ -374,7 +374,7 @@ class WPCM_Admin_Dashboard {
 					}
 
 					// Matches
-					$args               = array(
+					$args = array(
 						'tax_query'      => array(),
 						'order'          => 'DESC',
 						'orderby'        => 'post_date',

--- a/includes/admin/class-wpcm-admin-post-types.php
+++ b/includes/admin/class-wpcm-admin-post-types.php
@@ -256,12 +256,12 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 					// $default_club = get_default_club();
 					$title_format = get_match_title_format();
 					// $separator = get_option('wpcm_match_clubs_separator');
-					$home_id = '';
+					$home_id   = '';
 					$home_club = filter_input( INPUT_POST, 'wpcm_home_club', FILTER_VALIDATE_INT );
 					if ( $home_club ) {
 						$home_id = $home_club;
 					}
-					$away_id = '';
+					$away_id   = '';
 					$away_club = filter_input( INPUT_POST, 'wpcm_away_club', FILTER_VALIDATE_INT );
 					if ( $away_club ) {
 						$away_id = $away_club;
@@ -292,7 +292,7 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 				}
 
 				$kickoff = filter_input( INPUT_POST, 'wpcm_match_kickoff', FILTER_UNSAFE_RAW );
-				$date = filter_input( INPUT_POST, 'wpcm_match_date', FILTER_UNSAFE_RAW );
+				$date    = filter_input( INPUT_POST, 'wpcm_match_date', FILTER_UNSAFE_RAW );
 				if ( $kickoff && $date ) {
 					$date         = sanitize_text_field( $date );
 					$kickoff      = sanitize_text_field( $kickoff );
@@ -335,12 +335,12 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 
 			if ( 'wpcm_staff' == $data['post_type'] ) :
 
-				$firstname = '';
+				$firstname  = '';
 				$first_name = filter_input( INPUT_POST, '_wpcm_firstname', FILTER_UNSAFE_RAW );
 				if ( $first_name ) {
 					$firstname = sanitize_text_field( $first_name );
 				}
-				$lastname = '';
+				$lastname  = '';
 				$last_name = filter_input( INPUT_POST, '_wpcm_lastname', FILTER_UNSAFE_RAW );
 				if ( $last_name ) {
 					$lastname = sanitize_text_field( $last_name );
@@ -589,7 +589,7 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 						$season = '';
 					}
 					// $venue = wpcm_get_match_venue( $post->ID );
-					$venue = get_the_terms( $post->ID, 'wpcm_venue' );
+					$venue      = get_the_terms( $post->ID, 'wpcm_venue' );
 					$venue_slug = '';
 					if ( $venue && isset( $venue[0]->slug ) ) {
 						$venue_slug = $venue[0]->slug;
@@ -1142,7 +1142,7 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 			} elseif ( 'wpcm_staff' == $post_type ) {
 
 				$jobs  = get_terms( array(
-					'taxonomy' => 'wpcm_jobs',
+					'taxonomy'   => 'wpcm_jobs',
 					'hide_empty' => false,
 				) );
 				$clubs = get_pages( array( 'post_type' => 'wpcm_club' ) );
@@ -1320,7 +1320,7 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 				// season dropdown
 				$selected = filter_input( INPUT_GET, 'wpcm_season', FILTER_UNSAFE_RAW );
 				$selected = $selected ? sanitize_text_field( $selected ) : null;
-				$args = array(
+				$args     = array(
 					'show_option_all' => __( 'Show all seasons', 'wp-club-manager' ),
 					'taxonomy'        => 'wpcm_season',
 					'name'            => 'wpcm_season',
@@ -1432,7 +1432,7 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 
 			if ( 'wpcm_table' === $typenow ) {
 				// comp dropdown
-				$comp = filter_input( INPUT_GET, 'wpcm_comp', FILTER_UNSAFE_RAW );
+				$comp     = filter_input( INPUT_GET, 'wpcm_comp', FILTER_UNSAFE_RAW );
 				$selected = $comp ? sanitize_text_field( $comp ) : null;
 				$args     = array(
 					'show_option_all' => __( 'Show all competitions', 'wp-club-manager' ),
@@ -1443,7 +1443,7 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 				wpcm_dropdown_taxonomies( $args );
 				echo PHP_EOL;
 				// season dropdown
-				$season = filter_input( INPUT_GET, 'wpcm_season', FILTER_UNSAFE_RAW );
+				$season   = filter_input( INPUT_GET, 'wpcm_season', FILTER_UNSAFE_RAW );
 				$selected = $season ? sanitize_text_field( $season ) : null;
 				$args     = array(
 					'show_option_all' => __( 'Show all seasons', 'wp-club-manager' ),

--- a/includes/admin/class-wpcm-admin-settings.php
+++ b/includes/admin/class-wpcm-admin-settings.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'WPCM_Admin_Settings' ) ) :
 		/**
 		 * @var array
 		 */
-		private static $errors   = array();
+		private static $errors = array();
 		/**
 		 * @var array
 		 */
@@ -136,7 +136,7 @@ if ( ! class_exists( 'WPCM_Admin_Settings' ) ) :
 			self::get_settings_pages();
 
 			// Get current tab
-			$tab = filter_input( INPUT_GET, 'tab', FILTER_UNSAFE_RAW );
+			$tab         = filter_input( INPUT_GET, 'tab', FILTER_UNSAFE_RAW );
 			$current_tab = empty( $tab ) ? 'general' : sanitize_title( $tab );
 
 			// Save settings if data has been posted
@@ -914,7 +914,7 @@ if ( ! class_exists( 'WPCM_Admin_Settings' ) ) :
 					case 'multiselect':
 					case 'standings_columns':
 						$standings_columns = filter_input( INPUT_POST, $value['id'], FILTER_UNSAFE_RAW );
-						$option_value = wpcm_clean( stripslashes( sanitize_text_field( $standings_columns ) ) );
+						$option_value      = wpcm_clean( stripslashes( sanitize_text_field( $standings_columns ) ) );
 
 						break;
 
@@ -1005,7 +1005,7 @@ if ( ! class_exists( 'WPCM_Admin_Settings' ) ) :
 				// Find empty terms and destroy
 				$allterms = get_terms(
 					array(
-						'taxonomy' => $taxonomy,
+						'taxonomy'   => $taxonomy,
 						'hide_empty' => false,
 					)
 				);

--- a/includes/admin/class-wpcm-admin-taxonomies.php
+++ b/includes/admin/class-wpcm-admin-taxonomies.php
@@ -442,7 +442,7 @@ class WPCM_Admin_Taxonomies {
 	public function venue_add_new_extra_fields( $tag ) {
 
 		$args = array(
-			'taxonomy' => 'wpcm_venue',
+			'taxonomy'   => 'wpcm_venue',
 			'orderby'    => 'id',
 			'order'      => 'DESC',
 			'hide_empty' => false,

--- a/includes/admin/importers/class-wpcm-club-importer.php
+++ b/includes/admin/importers/class-wpcm-club-importer.php
@@ -39,7 +39,7 @@ if ( class_exists( 'WP_Importer' ) ) {
 		 */
 		public function import( $array = array(), $columns = array( 'post_title' ) ) {
 			$this->imported = 0;
-			$this->skipped = 0;
+			$this->skipped  = 0;
 
 			if ( ! is_array( $array ) || ! count( $array ) ) :
 				$this->footer();

--- a/includes/admin/importers/class-wpcm-importer.php
+++ b/includes/admin/importers/class-wpcm-importer.php
@@ -260,7 +260,7 @@ endwhile;
 		 * @return string
 		 */
 		public function format_data_from_csv( $data, $enc ) {
-			return ( 'UTF-8' == $enc ) ? $data : utf8_encode( $data );
+			return ( 'UTF-8' === $enc ) ? $data : mb_convert_encoding( $data, 'UTF-8', 'ISO-8859-1' );
 		}
 
 		/**

--- a/includes/admin/importers/class-wpcm-match-importer.php
+++ b/includes/admin/importers/class-wpcm-match-importer.php
@@ -82,7 +82,16 @@ if ( class_exists( 'WP_Importer' ) ) {
 
 				// Get home club ID
 				$home_club   = wpcm_array_value( $meta, 'wpcm_home_club' );
-				$home_object = get_page_by_title( $home_club, OBJECT, 'wpcm_club' );
+				$home_query  = new WP_Query(
+					array(
+						'post_type'      => 'wpcm_club',
+						'title'          => $home_club,
+						'posts_per_page' => 1,
+						'fields'         => 'ids',
+						'no_found_rows'  => true,
+					)
+				);
+				$home_object = $home_query->have_posts() ? get_post( $home_query->posts[0] ) : null;
 				if ( $home_object ) :
 					$home_id = $home_object->ID;
 				else :
@@ -98,7 +107,16 @@ if ( class_exists( 'WP_Importer' ) ) {
 
 				// Get away club ID
 				$away_club   = wpcm_array_value( $meta, 'wpcm_away_club' );
-				$away_object = get_page_by_title( $away_club, OBJECT, 'wpcm_club' );
+				$away_query  = new WP_Query(
+					array(
+						'post_type'      => 'wpcm_club',
+						'title'          => $away_club,
+						'posts_per_page' => 1,
+						'fields'         => 'ids',
+						'no_found_rows'  => true,
+					)
+				);
+				$away_object = $away_query->have_posts() ? get_post( $away_query->posts[0] ) : null;
 				if ( $away_object ) :
 					$away_id = $away_object->ID;
 				else :
@@ -216,7 +234,16 @@ if ( class_exists( 'WP_Importer' ) ) {
 						$player_name  = trim( $player_array[0] );
 						$player_stats = trim( $player_array[1] );
 
-						$player_title = get_page_by_title( $player_name, OBJECT, 'wpcm_player' );
+						$player_query = new WP_Query(
+							array(
+								'post_type'      => 'wpcm_player',
+								'title'          => $player_name,
+								'posts_per_page' => 1,
+								'fields'         => 'ids',
+								'no_found_rows'  => true,
+							)
+						);
+						$player_title = $player_query->have_posts() ? get_post( $player_query->posts[0] ) : null;
 						if ( $player_title ) :
 							$player_id = $player_title->ID;
 						else :

--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-result.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-result.php
@@ -65,7 +65,7 @@ class WPCM_Meta_Box_Match_Result {
 			$wpcm_cricket_outcome = get_post_meta( $post->ID, '_wpcm_cricket_outcome', true );
 			if ( ! is_array( $wpcm_cricket_outcome ) ) {
 				$wpcm_cricket_outcome = array( 0 => '', 1 => '', 2 => '' );
-			};
+			}
 		} else {
 			$goals = array_merge( array(
 				'total' => array(
@@ -111,14 +111,14 @@ class WPCM_Meta_Box_Match_Result {
 		<p>
 			<label class="selectit">
 				<input type="checkbox" name="wpcm_played" id="wpcm_played"
-					   value="1" <?php checked( true, $played ); ?> />
+						value="1" <?php checked( true, $played ); ?> />
 				<?php esc_html_e( 'Result', 'wp-club-manager' ); ?>
 			</label>
 		</p>
 		<p>
 			<label class="selectit">
 				<input type="checkbox" name="_wpcm_postponed" id="_wpcm_postponed"
-					   value="1" <?php checked( true, $postponed ); ?> />
+						value="1" <?php checked( true, $postponed ); ?> />
 				<?php esc_html_e( 'Postponed', 'wp-club-manager' ); ?>
 			</label>
 		</p>
@@ -174,37 +174,37 @@ class WPCM_Meta_Box_Match_Result {
 						<tr>
 							<th align="right"><?php esc_html_e( '1st Set', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q1][home]" id="wpcm_goals_q1_home"
-									   value="<?php echo (int) $box_goals['q1']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q1']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q1][away]" id="wpcm_goals_q1_away"
-									   value="<?php echo (int) $box_goals['q1']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q1']['away']; ?>" size="3"/></td>
 						</tr>
 						<tr>
 							<th align="right"><?php esc_html_e( '2nd Set', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q2][home]" id="wpcm_goals_q2_home"
-									   value="<?php echo (int) $box_goals['q2']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q2']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q2][away]" id="wpcm_goals_q2_away"
-									   value="<?php echo (int) $box_goals['q2']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q2']['away']; ?>" size="3"/></td>
 						</tr>
 						<tr>
 							<th align="right"><?php esc_html_e( '3rd Set', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q3][home]" id="wpcm_goals_q3_home"
-									   value="<?php echo (int) $box_goals['q3']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q3']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q3][away]" id="wpcm_goals_q3_away"
-									   value="<?php echo (int) $box_goals['q3']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q3']['away']; ?>" size="3"/></td>
 						</tr>
 						<tr>
 							<th align="right"><?php esc_html_e( '4th Set', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q4][home]" id="wpcm_goals_q4_home"
-									   value="<?php echo (int) $box_goals['q4']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q4']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q4][away]" id="wpcm_goals_q4_away"
-									   value="<?php echo (int) $box_goals['q4']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q4']['away']; ?>" size="3"/></td>
 						</tr>
 						<tr class="wpcm-ss-admin-tr-last">
 							<th align="right"><?php esc_html_e( '5th Set', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q5][home]" id="wpcm_goals_q5_home"
-									   value="<?php echo (int) $box_goals['q5']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q5']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q5][away]" id="wpcm_goals_q5_away"
-									   value="<?php echo (int) $box_goals['q5']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q5']['away']; ?>" size="3"/></td>
 						</tr>
 
 					<?php
@@ -230,30 +230,30 @@ class WPCM_Meta_Box_Match_Result {
 						<tr>
 							<th align="right"><?php esc_html_e( '1st Quarter', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q1][home]" id="wpcm_goals_q1_home"
-									   value="<?php echo (int) $box_goals['q1']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q1']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q1][away]" id="wpcm_goals_q1_away"
-									   value="<?php echo (int) $box_goals['q1']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q1']['away']; ?>" size="3"/></td>
 						</tr>
 						<tr>
 							<th align="right"><?php esc_html_e( '2nd Quarter', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q2][home]" id="wpcm_goals_q2_home"
-									   value="<?php echo (int) $box_goals['q2']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q2']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q2][away]" id="wpcm_goals_q2_away"
-									   value="<?php echo (int) $box_goals['q2']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q2']['away']; ?>" size="3"/></td>
 						</tr>
 						<tr>
 							<th align="right"><?php esc_html_e( '3rd Quarter', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q3][home]" id="wpcm_goals_q3_home"
-									   value="<?php echo (int) $box_goals['q3']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q3']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q3][away]" id="wpcm_goals_q3_away"
-									   value="<?php echo (int) $box_goals['q3']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q3']['away']; ?>" size="3"/></td>
 						</tr>
 						<tr class="wpcm-ss-admin-tr-last">
 							<th align="right"><?php esc_html_e( '4th Quarter', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q4][home]" id="wpcm_goals_q4_home"
-									   value="<?php echo (int) $box_goals['q4']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q4']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q4][away]" id="wpcm_goals_q4_away"
-									   value="<?php echo (int) $box_goals['q4']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q4']['away']; ?>" size="3"/></td>
 						</tr>
 
 					<?php
@@ -280,23 +280,23 @@ class WPCM_Meta_Box_Match_Result {
 						<tr>
 							<th align="right"><?php esc_html_e( '1st Period', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q1][home]" id="wpcm_goals_q1_home"
-									   value="<?php echo (int) $box_goals['q1']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q1']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q1][away]" id="wpcm_goals_q1_away"
-									   value="<?php echo (int) $box_goals['q1']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q1']['away']; ?>" size="3"/></td>
 						</tr>
 						<tr>
 							<th align="right"><?php esc_html_e( '2nd Period', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q2][home]" id="wpcm_goals_q2_home"
-									   value="<?php echo (int) $box_goals['q2']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q2']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q2][away]" id="wpcm_goals_q2_away"
-									   value="<?php echo (int) $box_goals['q2']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q2']['away']; ?>" size="3"/></td>
 						</tr>
 						<tr class="wpcm-ss-admin-tr-last">
 							<th align="right"><?php esc_html_e( '3rd Period', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q3][home]" id="wpcm_goals_q3_home"
-									   value="<?php echo (int) $box_goals['q3']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q3']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q3][away]" id="wpcm_goals_q3_away"
-									   value="<?php echo (int) $box_goals['q3']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q3']['away']; ?>" size="3"/></td>
 						</tr>
 					<?php
 					else :
@@ -311,9 +311,9 @@ class WPCM_Meta_Box_Match_Result {
 						<tr class="wpcm-ss-admin-tr-last">
 							<th align="right"><?php esc_html_e( 'Half Time', 'wp-club-manager' ); ?></th>
 							<td><input type="text" name="wpcm_goals[q1][home]" id="wpcm_goals_q1_home"
-									   value="<?php echo (int) $box_goals['q1']['home']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q1']['home']; ?>" size="3"/></td>
 							<td><input type="text" name="wpcm_goals[q1][away]" id="wpcm_goals_q1_away"
-									   value="<?php echo (int) $box_goals['q1']['away']; ?>" size="3"/></td>
+										value="<?php echo (int) $box_goals['q1']['away']; ?>" size="3"/></td>
 						</tr>
 
 					<?php endif; ?>
@@ -344,30 +344,30 @@ class WPCM_Meta_Box_Match_Result {
 					<tr>
 						<th align="right"><?php esc_html_e( 'Runs', 'wp-club-manager' ); ?></th>
 						<td><input type="text" name="wpcm_match_runs[home]" id="wpcm_match_runs_home"
-								   value="<?php echo (int) $wpcm_match_runs['home']; ?>" size="3"/></td>
+									value="<?php echo (int) $wpcm_match_runs['home']; ?>" size="3"/></td>
 						<td><input type="text" name="wpcm_match_runs[away]" id="wpcm_match_runs_away"
-								   value="<?php echo (int) $wpcm_match_runs['away']; ?>" size="3"/></td>
+									value="<?php echo (int) $wpcm_match_runs['away']; ?>" size="3"/></td>
 					</tr>
 					<tr>
 						<th align="right"><?php esc_html_e( 'Extras', 'wp-club-manager' ); ?></th>
 						<td><input type="text" name="wpcm_match_extras[home]" id="wpcm_match_extras_home"
-								   value="<?php echo (int) $wpcm_match_extras['home']; ?>" size="3"/></td>
+									value="<?php echo (int) $wpcm_match_extras['home']; ?>" size="3"/></td>
 						<td><input type="text" name="wpcm_match_extras[away]" id="wpcm_match_extras_away"
-								   value="<?php echo (int) $wpcm_match_extras['away']; ?>" size="3"/></td>
+									value="<?php echo (int) $wpcm_match_extras['away']; ?>" size="3"/></td>
 					</tr>
 					<tr>
 						<th align="right"><?php esc_html_e( 'Wickets', 'wp-club-manager' ); ?></th>
 						<td><input type="text" name="wpcm_match_wickets[home]" id="wpcm_match_wickets_home"
-								   value="<?php echo (int) $wpcm_match_wickets['home']; ?>" size="3"/></td>
+									value="<?php echo (int) $wpcm_match_wickets['home']; ?>" size="3"/></td>
 						<td><input type="text" name="wpcm_match_wickets[away]" id="wpcm_match_wickets_away"
-								   value="<?php echo (int) $wpcm_match_wickets['away']; ?>" size="3"/></td>
+									value="<?php echo (int) $wpcm_match_wickets['away']; ?>" size="3"/></td>
 					</tr>
 					<tr>
 						<th align="right"><?php esc_html_e( 'Overs', 'wp-club-manager' ); ?></th>
 						<td><input type="text" name="wpcm_match_overs[home]" id="wpcm_match_overs_home"
-								   value="<?php echo (float) $wpcm_match_overs['home']; ?>" size="3"/></td>
+									value="<?php echo (float) $wpcm_match_overs['home']; ?>" size="3"/></td>
 						<td><input type="text" name="wpcm_match_overs[away]" id="wpcm_match_overs_away"
-								   value="<?php echo (float) $wpcm_match_overs['away']; ?>" size="3"/></td>
+									value="<?php echo (float) $wpcm_match_overs['away']; ?>" size="3"/></td>
 					</tr>
 					</tbody>
 
@@ -381,9 +381,9 @@ class WPCM_Meta_Box_Match_Result {
 					<tr>
 						<th align="right"><?php esc_html_e( 'Final Score', 'wp-club-manager' ); ?></th>
 						<td><input type="text" name="wpcm_goals[total][home]" id="wpcm_goals_total_home"
-								   value="<?php echo (int) $goals['total']['home']; ?>" size="3"/></td>
+									value="<?php echo (int) $goals['total']['home']; ?>" size="3"/></td>
 						<td><input type="text" name="wpcm_goals[total][away]" id="wpcm_goals_total_away"
-								   value="<?php echo (int) $goals['total']['away']; ?>" size="3"/></td>
+									value="<?php echo (int) $goals['total']['away']; ?>" size="3"/></td>
 					</tr>
 					</tbody>
 
@@ -416,7 +416,7 @@ class WPCM_Meta_Box_Match_Result {
 					?>
 
 					<input type="number" class="wpcm_cricket_outcome" name="cricket_outcome_1" min="0" max="999"
-						   value="<?php echo esc_html( $wpcm_cricket_outcome[1] ); ?>"/>
+							value="<?php echo esc_html( $wpcm_cricket_outcome[1] ); ?>"/>
 
 					<?php
 					wpclubmanager_wp_select( array(
@@ -445,9 +445,9 @@ class WPCM_Meta_Box_Match_Result {
 					<tr>
 						<th align="right"><?php esc_html_e( 'Bonus Points', 'wp-club-manager' ); ?></th>
 						<td><input type="text" name="wpcm_bonus[home]" id="wpcm_bonus_home"
-								   value="<?php echo (int) $bonus['home']; ?>" size="3"/></td>
+									value="<?php echo (int) $bonus['home']; ?>" size="3"/></td>
 						<td><input type="text" name="wpcm_bonus[away]" id="wpcm_bonus_away"
-								   value="<?php echo (int) $bonus['away']; ?>" size="3"/></td>
+									value="<?php echo (int) $bonus['away']; ?>" size="3"/></td>
 					</tr>
 					</tbody>
 				</table>
@@ -461,16 +461,16 @@ class WPCM_Meta_Box_Match_Result {
 					<tr>
 						<th align="right"><?php esc_html_e( 'Goals', 'wp-club-manager' ); ?></th>
 						<td><input type="text" name="wpcm_gaa_goals[home]" id="wpcm_gaa_goals_home"
-								   value="<?php echo (int) $gaa_goals['home']; ?>" size="3"/></td>
+									value="<?php echo (int) $gaa_goals['home']; ?>" size="3"/></td>
 						<td><input type="text" name="wpcm_gaa_goals[away]" id="wpcm_gaa_goals_away"
-								   value="<?php echo (int) $gaa_goals['away']; ?>" size="3"/></td>
+									value="<?php echo (int) $gaa_goals['away']; ?>" size="3"/></td>
 					</tr>
 					<tr>
 						<th align="right"><?php esc_html_e( 'Points', 'wp-club-manager' ); ?></th>
 						<td><input type="text" name="wpcm_gaa_points[home]" id="wpcm_gaa_points_home"
-								   value="<?php echo (int) $gaa_points['home']; ?>" size="3"/></td>
+									value="<?php echo (int) $gaa_points['home']; ?>" size="3"/></td>
 						<td><input type="text" name="wpcm_gaa_points[away]" id="wpcm_gaa_points_away"
-								   value="<?php echo (int) $gaa_points['away']; ?>" size="3"/></td>
+									value="<?php echo (int) $gaa_points['away']; ?>" size="3"/></td>
 					</tr>
 					</tbody>
 				</table>
@@ -482,7 +482,7 @@ class WPCM_Meta_Box_Match_Result {
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_overtime" id="wpcm_overtime"
-							   value="1" <?php checked( true, $overtime ); ?> />
+								value="1" <?php checked( true, $overtime ); ?> />
 						<?php esc_html_e( 'Overtime', 'wp-club-manager' ); ?>
 					</label>
 				</p>
@@ -494,7 +494,7 @@ class WPCM_Meta_Box_Match_Result {
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_shootout" id="wpcm_shootout"
-							   value="1" <?php checked( true, $shootout ); ?> />
+								value="1" <?php checked( true, $shootout ); ?> />
 						<?php esc_html_e( 'Shootout', 'wp-club-manager' ); ?>
 					</label>
 				</p>
@@ -506,7 +506,7 @@ class WPCM_Meta_Box_Match_Result {
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_overtime" id="wpcm_overtime"
-							   value="1" <?php checked( true, $overtime ); ?> />
+								value="1" <?php checked( true, $overtime ); ?> />
 						<?php esc_html_e( 'Extra Time', 'wp-club-manager' ); ?>
 					</label>
 				</p>
@@ -514,7 +514,7 @@ class WPCM_Meta_Box_Match_Result {
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_shootout" id="wpcm_shootout"
-							   value="1" <?php checked( true, $shootout ); ?> />
+								value="1" <?php checked( true, $shootout ); ?> />
 						<?php esc_html_e( 'Penalties', 'wp-club-manager' ); ?>
 					</label>
 				</p>
@@ -524,9 +524,9 @@ class WPCM_Meta_Box_Match_Result {
 					<tr>
 						<th align="right"><?php esc_html_e( 'Score', 'wp-club-manager' ); ?></th>
 						<td><input type="text" name="wpcm_shootout_score[home]" id="wpcm_shootout_home"
-								   value="<?php echo (int) $shootout_score['home']; ?>" size="3"/></td>
+									value="<?php echo (int) $shootout_score['home']; ?>" size="3"/></td>
 						<td><input type="text" name="wpcm_shootout_score[away]" id="wpcm_shootout_away"
-								   value="<?php echo (int) $shootout_score['away']; ?>" size="3"/></td>
+									value="<?php echo (int) $shootout_score['away']; ?>" size="3"/></td>
 					</tr>
 					</tbody>
 				</table>
@@ -592,12 +592,12 @@ class WPCM_Meta_Box_Match_Result {
 
 			$cricket_outcome = filter_input( INPUT_POST, 'cricket_outcome_0', FILTER_UNSAFE_RAW );
 			if ( $cricket_outcome && '' != $cricket_outcome ) {
-				$outcome_0       = sanitize_text_field( $cricket_outcome );
+				$outcome_0         = sanitize_text_field( $cricket_outcome );
 				$cricket_outcome_1 = filter_input( INPUT_POST, 'cricket_outcome_1', FILTER_UNSAFE_RAW );
 				$cricket_outcome_2 = filter_input( INPUT_POST, 'cricket_outcome_2', FILTER_UNSAFE_RAW );
-				$outcome_1       = sanitize_text_field( $cricket_outcome_1 );
-				$outcome_2       = sanitize_text_field( $cricket_outcome_2 );
-				$cricket_outcome = array( $outcome_0, $outcome_1, $outcome_2 );
+				$outcome_1         = sanitize_text_field( $cricket_outcome_1 );
+				$outcome_2         = sanitize_text_field( $cricket_outcome_2 );
+				$cricket_outcome   = array( $outcome_0, $outcome_1, $outcome_2 );
 				update_post_meta( $post_id, '_wpcm_cricket_outcome', $cricket_outcome );
 			}
 		} else {

--- a/includes/admin/views/html-admin-page-league-dashboard.php
+++ b/includes/admin/views/html-admin-page-league-dashboard.php
@@ -82,7 +82,7 @@
 				<div class="extra content">
 					<div class="ui two buttons">
 						<a class="ui basic button"
-						   href="<?php echo esc_url( get_edit_post_link( $table_id ) ); ?>"><?php esc_html_e( 'Manage table', 'wp-club-manager' ); ?></a>
+							href="<?php echo esc_url( get_edit_post_link( $table_id ) ); ?>"><?php esc_html_e( 'Manage table', 'wp-club-manager' ); ?></a>
 					</div>
 				</div>
 
@@ -97,7 +97,7 @@
 			<div class="extra content">
 				<div class="ui two buttons">
 					<a class="ui basic button"
-					   href="<?php echo esc_url( admin_url( 'post-new.php?post_type=wpcm_table' ) ); ?>"><?php esc_html_e( 'Create new league table', 'wp-club-manager' ); ?></a>
+						href="<?php echo esc_url( admin_url( 'post-new.php?post_type=wpcm_table' ) ); ?>"><?php esc_html_e( 'Create new league table', 'wp-club-manager' ); ?></a>
 				</div>
 			</div>
 
@@ -164,7 +164,7 @@
 											<span class="venue"><?php echo esc_html( $venue['name'] ); ?></span>
 										</div>
 										<a class="header"
-										   href="<?php echo esc_url( get_edit_post_link( $played_match->ID ) ); ?>"><?php echo esc_html( $played_match->post_title ); ?> </a>
+											href="<?php echo esc_url( get_edit_post_link( $played_match->ID ) ); ?>"><?php echo esc_html( $played_match->post_title ); ?> </a>
 										<div class="meta">
 											<span class="competition"><?php echo esc_html( $comp[0] ); ?></span>
 										</div>
@@ -193,9 +193,9 @@
 				<div class="extra content">
 					<div class="ui two buttons">
 						<a class="ui basic button"
-						   href="<?php echo esc_url( $new_query ); ?>"><?php esc_html_e( 'Manage matches', 'wp-club-manager' ); ?></a>
+							href="<?php echo esc_url( $new_query ); ?>"><?php esc_html_e( 'Manage matches', 'wp-club-manager' ); ?></a>
 						<a class="ui basic button"
-						   href="<?php echo esc_url( admin_url( 'post-new.php?post_type=wpcm_match' ) ); ?>"><?php esc_html_e( 'Add new match', 'wp-club-manager' ); ?></a>
+							href="<?php echo esc_url( admin_url( 'post-new.php?post_type=wpcm_match' ) ); ?>"><?php esc_html_e( 'Add new match', 'wp-club-manager' ); ?></a>
 					</div>
 				</div>
 			</div>
@@ -241,7 +241,7 @@
 											<span class="venue"><?php echo esc_html( $venue['name'] ); ?></span>
 										</div>
 										<a class="header"
-										   href="<?php echo esc_url( get_edit_post_link( $future_match->ID ) ); ?>"><?php echo esc_html( $played_match->post_title ); ?></a>
+											href="<?php echo esc_url( get_edit_post_link( $future_match->ID ) ); ?>"><?php echo esc_html( $played_match->post_title ); ?></a>
 										<div class="meta">
 											<span class="competition"><?php echo esc_html( $comp[0] ); ?></span>
 										</div>
@@ -270,9 +270,9 @@
 				<div class="extra content">
 					<div class="ui two buttons">
 						<a class="ui basic button"
-						   href="<?php echo esc_url( $new_query ); ?>"><?php esc_html_e( 'Manage matches', 'wp-club-manager' ); ?></a>
+							href="<?php echo esc_url( $new_query ); ?>"><?php esc_html_e( 'Manage matches', 'wp-club-manager' ); ?></a>
 						<a class="ui basic button"
-						   href="<?php echo esc_url( admin_url( 'post-new.php?post_type=wpcm_match' ) ); ?>"><?php esc_html_e( 'Add new match', 'wp-club-manager' ); ?></a>
+							href="<?php echo esc_url( admin_url( 'post-new.php?post_type=wpcm_match' ) ); ?>"><?php esc_html_e( 'Add new match', 'wp-club-manager' ); ?></a>
 					</div>
 				</div>
 			</div>

--- a/includes/class-wpcm-ajax.php
+++ b/includes/class-wpcm-ajax.php
@@ -202,7 +202,7 @@ class WPCM_AJAX {
 					?>
 					<label for="<?php echo esc_attr( $key ); ?>" class="button">
 						<input type="checkbox" name="<?php echo esc_attr( $key ); ?>"
-							   value="<?php echo esc_html( $key ); ?>" <?php echo( 'show_abbr' == $key ? '' : 'checked="checked"' ); ?>><?php echo esc_html( $value ); ?>
+								value="<?php echo esc_html( $key ); ?>" <?php echo( 'show_abbr' == $key ? '' : 'checked="checked"' ); ?>><?php echo esc_html( $value ); ?>
 					</label>
 					<?php
 				}
@@ -226,10 +226,10 @@ class WPCM_AJAX {
 			<?php do_action( 'wpclubmanager_ajax_shortcode_form', 'match_opponents' ); ?>
 			<p class="submit">
 				<input type="button" id="option-submit" class="button-primary"
-					   value="<?php esc_html_e( 'Insert Match Opponents', 'wp-club-manager' ); ?>"
-					   onclick="insertWPClubManager('match_opponents');"/>
+						value="<?php esc_html_e( 'Insert Match Opponents', 'wp-club-manager' ); ?>"
+						onclick="insertWPClubManager('match_opponents');"/>
 				<a class="button-secondary" onclick="tb_remove();"
-				   title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
+					title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
 			</p>
 		</div>
 
@@ -386,7 +386,7 @@ class WPCM_AJAX {
 					?>
 					<label for="<?php echo esc_attr( $key ); ?>" class="button">
 						<input type="checkbox" name="<?php echo esc_attr( $key ); ?>"
-							   value="<?php echo esc_html( $key ); ?>" <?php echo( 'show_abbr' == $key ? '' : 'checked="checked"' ); ?>><?php echo esc_html( $value ); ?>
+								value="<?php echo esc_html( $key ); ?>" <?php echo( 'show_abbr' == $key ? '' : 'checked="checked"' ); ?>><?php echo esc_html( $value ); ?>
 					</label>
 					<?php
 				}
@@ -410,10 +410,10 @@ class WPCM_AJAX {
 			<?php do_action( 'wpclubmanager_ajax_shortcode_form', 'match_list' ); ?>
 			<p class="submit">
 				<input type="button" id="option-submit" class="button-primary"
-					   value="<?php esc_html_e( 'Insert Match List', 'wp-club-manager' ); ?>"
-					   onclick="insertWPClubManager('match_list');"/>
+						value="<?php esc_html_e( 'Insert Match List', 'wp-club-manager' ); ?>"
+						onclick="insertWPClubManager('match_list');"/>
 				<a class="button-secondary" onclick="tb_remove();"
-				   title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
+					title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
 			</p>
 		</div>
 
@@ -533,7 +533,7 @@ class WPCM_AJAX {
 						?>
 						<label for="<?php echo esc_attr( $key ); ?>" class="button">
 							<input type="checkbox" id="stats-<?php echo esc_attr( $key ); ?>" name="columns[]"
-								   value="<?php echo esc_html( $key ); ?>"<?php echo( in_array( $key, $defaults ) ? ' checked' : '' ); ?>><?php echo esc_html( $value ); ?>
+									value="<?php echo esc_html( $key ); ?>"<?php echo( in_array( $key, $defaults ) ? ' checked' : '' ); ?>><?php echo esc_html( $value ); ?>
 						</label>
 					<?php } ?>
 				</div>
@@ -556,10 +556,10 @@ class WPCM_AJAX {
 			<?php do_action( 'wpclubmanager_ajax_shortcode_form', 'player_list' ); ?>
 			<p class="submit">
 				<input type="button" id="option-submit" class="button-primary"
-					   value="<?php esc_html_e( 'Insert Player List', 'wp-club-manager' ); ?>"
-					   onclick="insertWPClubManager('player_list');"/>
+						value="<?php esc_html_e( 'Insert Player List', 'wp-club-manager' ); ?>"
+						onclick="insertWPClubManager('player_list');"/>
 				<a class="button-secondary" onclick="tb_remove();"
-				   title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
+					title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
 			</p>
 
 		</div>
@@ -678,10 +678,10 @@ class WPCM_AJAX {
 			<?php do_action( 'wpclubmanager_ajax_shortcode_form', 'player_gallery' ); ?>
 			<p class="submit">
 				<input type="button" id="option-submit" class="button-primary"
-					   value="<?php esc_html_e( 'Insert Player Gallery', 'wp-club-manager' ); ?>"
-					   onclick="insertWPClubManager('player_gallery');"/>
+						value="<?php esc_html_e( 'Insert Player Gallery', 'wp-club-manager' ); ?>"
+						onclick="insertWPClubManager('player_gallery');"/>
 				<a class="button-secondary" onclick="tb_remove();"
-				   title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
+					title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
 			</p>
 
 		</div>
@@ -799,7 +799,7 @@ class WPCM_AJAX {
 						?>
 						<label for="<?php echo esc_attr( $key ); ?>" class="button">
 							<input type="checkbox" id="stats-<?php echo esc_attr( $key ); ?>" name="columns[]"
-								   value="<?php echo esc_html( $key ); ?>"<?php echo( in_array( $key, $defaults ) ? ' checked' : '' ); ?>><?php echo esc_html( $value ); ?>
+									value="<?php echo esc_html( $key ); ?>"<?php echo( in_array( $key, $defaults ) ? ' checked' : '' ); ?>><?php echo esc_html( $value ); ?>
 						</label>
 					<?php } ?>
 				</div>
@@ -822,10 +822,10 @@ class WPCM_AJAX {
 			<?php do_action( 'wpclubmanager_ajax_shortcode_form', 'staff_list' ); ?>
 			<p class="submit">
 				<input type="button" id="option-submit" class="button-primary"
-					   value="<?php esc_html_e( 'Insert Staff List', 'wp-club-manager' ); ?>"
-					   onclick="insertWPClubManager('staff_list');"/>
+						value="<?php esc_html_e( 'Insert Staff List', 'wp-club-manager' ); ?>"
+						onclick="insertWPClubManager('staff_list');"/>
 				<a class="button-secondary" onclick="tb_remove();"
-				   title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
+					title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
 			</p>
 
 		</div>
@@ -942,10 +942,10 @@ class WPCM_AJAX {
 			<?php do_action( 'wpclubmanager_ajax_shortcode_form', 'staff_gallery' ); ?>
 			<p class="submit">
 				<input type="button" id="option-submit" class="button-primary"
-					   value="<?php esc_html_e( 'Insert Staff Gallery', 'wp-club-manager' ); ?>"
-					   onclick="insertWPClubManager('staff_gallery');"/>
+						value="<?php esc_html_e( 'Insert Staff Gallery', 'wp-club-manager' ); ?>"
+						onclick="insertWPClubManager('staff_gallery');"/>
 				<a class="button-secondary" onclick="tb_remove();"
-				   title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
+					title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
 			</p>
 
 		</div>
@@ -1023,7 +1023,7 @@ class WPCM_AJAX {
 				<?php foreach ( $stats as $key => $value ) { ?>
 					<label class="button">
 						<input type="checkbox" name="columns[]" id="columns-<?php echo esc_attr( $key ); ?>"
-							   value="<?php echo esc_html( $key ); ?>" checked="checked"><?php echo esc_html( $value ); ?>
+								value="<?php echo esc_html( $key ); ?>" checked="checked"><?php echo esc_html( $value ); ?>
 					</label>
 				<?php } ?>
 			</p>
@@ -1045,10 +1045,10 @@ class WPCM_AJAX {
 			<?php do_action( 'wpclubmanager_ajax_shortcode_form', 'league_table' ); ?>
 			<p class="submit">
 				<input type="button" id="option-submit" class="button-primary"
-					   value="<?php esc_html_e( 'Insert League Table', 'wp-club-manager' ); ?>"
-					   onclick="insertWPClubManager('league_table');"/>
+						value="<?php esc_html_e( 'Insert League Table', 'wp-club-manager' ); ?>"
+						onclick="insertWPClubManager('league_table');"/>
 				<a class="button-secondary" onclick="tb_remove();"
-				   title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
+					title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
 			</p>
 		</div>
 
@@ -1094,10 +1094,10 @@ class WPCM_AJAX {
 			<?php do_action( 'wpclubmanager_ajax_shortcode_form', 'map_venue' ); ?>
 			<p class="submit">
 				<input type="button" id="option-submit" class="button-primary"
-					   value="<?php esc_html_e( 'Insert Venue Map', 'wp-club-manager' ); ?>"
-					   onclick="insertWPClubManager('map_venue');"/>
+						value="<?php esc_html_e( 'Insert Venue Map', 'wp-club-manager' ); ?>"
+						onclick="insertWPClubManager('map_venue');"/>
 				<a class="button-secondary" onclick="tb_remove();"
-				   title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
+					title="<?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?>"><?php esc_html_e( 'Cancel', 'wp-club-manager' ); ?></a>
 			</p>
 		</div>
 

--- a/includes/class-wpcm-install.php
+++ b/includes/class-wpcm-install.php
@@ -189,7 +189,7 @@ if ( ! class_exists( 'WPCM_Install' ) ) :
 			if ( ! get_option( 'wpclubmanager_installed' ) ) {
 				add_option( 'wpcm_mode', 'club' );
 				// Configure default sport
-				$post  = 'soccer';
+				$post = 'soccer';
 				if ( null !== WPCM()->sports ) {
 					$sport = WPCM()->sports->$post;
 					WPCM_Admin_Settings::configure_sport( $sport );

--- a/includes/class-wpcm-reset-database.php
+++ b/includes/class-wpcm-reset-database.php
@@ -47,7 +47,7 @@ class WPCM_Reset_Database {
 	 * @return void
 	 */
 	protected function delete_terms( $taxonomy ) {
-		$terms         = get_terms( array(
+		$terms = get_terms( array(
 			'taxonomy'   => $taxonomy,
 			'hide_empty' => false,
 		) );

--- a/includes/widgets/class-wpcm-birthdays-widget.php
+++ b/includes/widgets/class-wpcm-birthdays-widget.php
@@ -112,7 +112,7 @@ class WPCM_Birthdays_Widget extends WPCM_Widget {
 
 			$dob = get_post_meta( $player->ID, 'wpcm_dob', true );
 			if ( $dob ) {
-				list( $y, $m, $d ) = explode( '-', $dob );
+				list( $y, $m, $d )    = explode( '-', $dob );
 				$month_day            = gmdate( 'Y-' . $m . '-' . $d );
 				$posts[ $player->ID ] = $month_day;
 			}

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -452,7 +452,7 @@ if ( ! function_exists( 'get_wpcm_club_auto_stats' ) ) {
 					$output['b']   += $hb;
 					$output['pts'] += $hb;
 				}
-				$output['pts'] += $won * (int) get_option( 'wpcm_standings_win_points', 3 ) + $lost * (int)get_option( 'wpcm_standings_loss_points', 0 );
+				$output['pts'] += $won * (int) get_option( 'wpcm_standings_win_points', 3 ) + $lost * (int) get_option( 'wpcm_standings_loss_points', 0 );
 			}
 			if ( $postponed && 'home_win' == $walkover ) {
 				++$output['p'];

--- a/templates/single-match/box-scores.php
+++ b/templates/single-match/box-scores.php
@@ -185,12 +185,14 @@ if ( in_array( $sport, $sports ) ) {
 			if ( 'yes' === get_option( 'wpcm_hide_scores' ) && ! is_user_logged_in() ) {
 				echo esc_html_x( 'HT:', 'Half time', 'wp-club-manager' );
 				?>
-				<?php esc_html_e( 'x', 'wp-club-manager' ); ?> <?php echo esc_html( $sep ); ?> <?php
+				<?php esc_html_e( 'x', 'wp-club-manager' ); ?> <?php echo esc_html( $sep ); ?>
+				<?php
 					esc_html_e( 'x', 'wp-club-manager' );
 			} else {
 				echo esc_html_x( 'HT:', 'Half time', 'wp-club-manager' );
 				?>
-				<?php echo esc_html( $intgoals['q1']['home'] ); ?> <?php echo esc_html( $sep ); ?> <?php
+				<?php echo esc_html( $intgoals['q1']['home'] ); ?> <?php echo esc_html( $sep ); ?>
+				<?php
 					echo esc_html( $intgoals['q1']['away'] );
 			}
 			?>

--- a/templates/single-match/lineup.php
+++ b/templates/single-match/lineup.php
@@ -48,7 +48,7 @@ if ( $played && $players ) {
 								<?php
 							}
 						}
-						if ( 'yes' === get_option( 'wpcm_show_stats_greencards' ) && 'yes' === get_option( 'wpcm_match_show_stats_greencards' ) || 'yes' === get_option( 'wpcm_show_stats_yellowcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_yellowcards' ) || 'yes' === get_option( 'wpcm_show_stats_blackcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_blackcards' ) || 'yes' === get_option( 'wpcm_show_stats_redcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_redcards' ) ) {
+						if ( ( 'yes' === get_option( 'wpcm_show_stats_greencards' ) && 'yes' === get_option( 'wpcm_match_show_stats_greencards' ) ) || ( 'yes' === get_option( 'wpcm_show_stats_yellowcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_yellowcards' ) ) || ( 'yes' === get_option( 'wpcm_show_stats_blackcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_blackcards' ) ) || ( 'yes' === get_option( 'wpcm_show_stats_redcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_redcards' ) ) ) {
 							?>
 
 								<th class="notes"><?php esc_html_e( 'Cards', 'wp-club-manager' ); ?></th>
@@ -78,7 +78,7 @@ if ( $played && $players ) {
 
 		<?php
 	}
-	if ( array_key_exists( 'subs', $players ) && is_array( $players['subs'] ) || is_array( $subs_not_used ) ) {
+	if ( ( array_key_exists( 'subs', $players ) && is_array( $players['subs'] ) ) || is_array( $subs_not_used ) ) {
 		?>
 
 		<div class="wpcm-match-stats-subs">
@@ -107,7 +107,7 @@ if ( $played && $players ) {
 								<?php
 							}
 						}
-						if ( 'yes' === get_option( 'wpcm_show_stats_greencards' ) && 'yes' === get_option( 'wpcm_match_show_stats_greencards' ) || 'yes' === get_option( 'wpcm_show_stats_yellowcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_yellowcards' ) || 'yes' === get_option( 'wpcm_show_stats_blackcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_blackcards' ) || 'yes' === get_option( 'wpcm_show_stats_redcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_redcards' ) ) {
+						if ( ( 'yes' === get_option( 'wpcm_show_stats_greencards' ) && 'yes' === get_option( 'wpcm_match_show_stats_greencards' ) ) || ( 'yes' === get_option( 'wpcm_show_stats_yellowcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_yellowcards' ) ) || ( 'yes' === get_option( 'wpcm_show_stats_blackcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_blackcards' ) ) || ( 'yes' === get_option( 'wpcm_show_stats_redcards' ) && 'yes' === get_option( 'wpcm_match_show_stats_redcards' ) ) ) {
 							?>
 
 								<th class="notes"><?php esc_html_e( 'Cards', 'wp-club-manager' ); ?></th>

--- a/uninstall.php
+++ b/uninstall.php
@@ -17,7 +17,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 global $wpdb, $wp_roles;
 
 // Roles + caps
-include 'includes/class-wpcm-install.php';
+require 'includes/class-wpcm-install.php';
 $installer = new WPCM_Install();
 $installer->remove_roles();
 


### PR DESCRIPTION
## Summary

Resolves all 20 PHPCS errors so the PHPCS CI check passes. 709 warnings remain but are non-blocking.

## Changes

- **Match importer**: Replace 3x deprecated `get_page_by_title()` with `WP_Query` (deprecated WP 6.2)
- **CSV importer**: Replace deprecated `utf8_encode()` with `mb_convert_encoding()`, fix loose `==` to `===`
- **Lineup template**: Add parentheses to mixed `&&`/`||` operators (3 instances)
- **PHPCBF auto-fixes**: Formatting across 14 files

## Test plan

- [ ] PHPCS CI passes with 0 errors
- [ ] WPUnit tests pass
- [ ] Playwright E2E passes