### PR TITLE
Fix: sub appearances count showing incorrectly (#83)

### DIFF
--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -802,11 +802,9 @@ function get_player_subs_total( $id = null, $season = null, $team = null ) {
 
 	$size = count( $matches );
 
-	$total_subs = '0';
+	$total_subs = 0;
 
 	if ( $size > 0 ) {
-
-		$total_subs = 0;
 
 		foreach ( $matches as $match ) {
 

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -812,7 +812,7 @@ function get_player_subs_total( $id = null, $season = null, $team = null ) {
 
 			$player = maybe_unserialize( get_post_meta( $match->ID, 'wpcm_players', true ) );
 
-			if ( is_array( $player ) && array_key_exists( 'subs', $player ) && array_key_exists( $id, $player['subs'] ) && ! empty( $player['subs'][ $id ]['checked'] ) ) {
+			if ( is_array( $player ) && array_key_exists( 'subs', $player ) && is_array( $player['subs'] ) && array_key_exists( $id, $player['subs'] ) && ! empty( $player['subs'][ $id ]['checked'] ) ) {
 
 				++$total_subs;
 

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -812,7 +812,7 @@ function get_player_subs_total( $id = null, $season = null, $team = null ) {
 
 			$player = maybe_unserialize( get_post_meta( $match->ID, 'wpcm_players', true ) );
 
-			if ( is_array( $player ) && array_key_exists( 'subs', $player ) && array_key_exists( $id, $player['subs'] ) ) {
+			if ( is_array( $player ) && array_key_exists( 'subs', $player ) && array_key_exists( $id, $player['subs'] ) && ! empty( $player['subs'][ $id ]['checked'] ) ) {
 
 				++$total_subs;
 

--- a/templates/single-player/stats-table.php
+++ b/templates/single-player/stats-table.php
@@ -51,14 +51,14 @@ $custom_stats = get_post_meta( $post->ID, '_wpcm_custom_player_stats', true ); ?
 						if ( get_option( 'wpcm_show_stats_subs' ) === 'yes' ) {
 							$subs = get_player_subs_total( $post->ID, $season, $team );
 							if ( $subs > 0 ) {
-								$sub = ' <span class="sub-appearances">(' . $subs . ')</span>';
+								$sub = ' <span class="sub-appearances">(' . absint( $subs ) . ')</span>';
 							} else {
 								$sub = '';
 							}
 						}
 						?>
 
-						<td><span data-index="appearances"><?php wpcm_stats_value( $stats, 'total', 'appearances' ); ?><?php echo wp_kses_post( 'yes' === get_option( 'wpcm_show_stats_subs' ) ? $sub : '' ); ?></span></td>
+						<td><span data-index="appearances"><?php wpcm_stats_value( $stats, 'total', 'appearances' ); ?><?php echo wp_kses( 'yes' === get_option( 'wpcm_show_stats_subs' ) ? $sub : '', array( 'span' => array( 'class' => array() ) ) ); ?></span></td>
 
 						<?php
 					}

--- a/templates/single-player/stats-table.php
+++ b/templates/single-player/stats-table.php
@@ -58,7 +58,7 @@ $custom_stats = get_post_meta( $post->ID, '_wpcm_custom_player_stats', true ); ?
 						}
 						?>
 
-						<td><span data-index="appearances"><?php wpcm_stats_value( $stats, 'total', 'appearances' ); ?><?php echo esc_html( 'yes' === get_option( 'wpcm_show_stats_subs' ) ? $sub : '' ); ?></span></td>
+						<td><span data-index="appearances"><?php wpcm_stats_value( $stats, 'total', 'appearances' ); ?><?php echo wp_kses_post( 'yes' === get_option( 'wpcm_show_stats_subs' ) ? $sub : '' ); ?></span></td>
 
 						<?php
 					}

--- a/tests/wpunit/SubAppearancesTest.php
+++ b/tests/wpunit/SubAppearancesTest.php
@@ -178,6 +178,35 @@ class SubAppearancesTest extends WPCMTestCase {
 		$this->assertEquals( 0, $subs );
 	}
 
+	public function test_already_unserialized_meta_is_handled() {
+		$match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Subs Unserialized Meta Match',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $match_id, 'wpcm_home_club', $this->club_id );
+		update_post_meta( $match_id, 'wpcm_away_club', $this->away_club_id );
+		update_post_meta( $match_id, 'wpcm_played', '1' );
+
+		// Store as array (no manual serialize) — maybe_unserialize() should handle this.
+		update_post_meta( $match_id, 'wpcm_players', array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 0,
+				),
+			),
+		) );
+
+		$this->match_ids[] = $match_id;
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 1, $subs, 'Already-unserialized meta should be handled by maybe_unserialize' );
+	}
+
 	public function test_subs_total_returns_zero_with_no_matches() {
 		$subs = get_player_subs_total( $this->player_id );
 

--- a/tests/wpunit/SubAppearancesTest.php
+++ b/tests/wpunit/SubAppearancesTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Tests for sub appearances count on the player profile.
+ *
+ * Verifies that get_player_subs_total() correctly counts only
+ * checked substitute appearances, and that unchecked legacy subs
+ * are excluded.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/83
+ */
+
+class SubAppearancesTest extends WPCMTestCase {
+
+	/** @var int */
+	private $club_id;
+
+	/** @var int */
+	private $away_club_id;
+
+	/** @var int */
+	private $player_id;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		update_option( 'wpcm_sport', 'soccer' );
+
+		$this->club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Subs Test FC',
+			'post_status' => 'publish',
+		) );
+
+		$this->away_club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Subs Away United',
+			'post_status' => 'publish',
+		) );
+
+		update_option( 'wpcm_default_club', $this->club_id );
+
+		$this->player_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_player',
+			'post_title'  => 'Subs Test Player',
+			'post_status' => 'publish',
+		) );
+	}
+
+	public function _tearDown() {
+		wp_delete_post( $this->player_id, true );
+		wp_delete_post( $this->club_id, true );
+		wp_delete_post( $this->away_club_id, true );
+		delete_option( 'wpcm_default_club' );
+
+		parent::_tearDown();
+	}
+
+	/**
+	 * Helper to create a match with player data.
+	 *
+	 * @param array $players Serialised wpcm_players structure.
+	 * @return int Match post ID.
+	 */
+	private function create_match( $players ) {
+		$match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Subs Test Match',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $match_id, 'wpcm_home_club', $this->club_id );
+		update_post_meta( $match_id, 'wpcm_away_club', $this->away_club_id );
+		update_post_meta( $match_id, 'wpcm_played', '1' );
+		update_post_meta( $match_id, 'wpcm_players', serialize( $players ) );
+
+		return $match_id;
+	}
+
+	// -------------------------------------------------------------------
+	// get_player_subs_total() — core sub count
+	// -------------------------------------------------------------------
+
+	public function test_checked_sub_is_counted() {
+		$match_id = $this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 0,
+					'assists' => 0,
+				),
+			),
+		) );
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 1, $subs );
+
+		wp_delete_post( $match_id, true );
+	}
+
+	public function test_unchecked_sub_is_not_counted() {
+		// Legacy data: player in subs array but without 'checked' key.
+		$match_id = $this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'goals'   => 0,
+					'assists' => 0,
+				),
+			),
+		) );
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 0, $subs, 'Unchecked sub should not be counted' );
+
+		wp_delete_post( $match_id, true );
+	}
+
+	public function test_multiple_matches_count_only_checked_subs() {
+		// Match 1: player is a checked sub.
+		$match1 = $this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 1,
+				),
+			),
+		) );
+
+		// Match 2: player is in subs but NOT checked (legacy data).
+		$match2 = $this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'goals' => 0,
+				),
+			),
+		) );
+
+		// Match 3: player is a checked sub.
+		$match3 = $this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 0,
+				),
+			),
+		) );
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 2, $subs, 'Only checked subs should be counted' );
+
+		wp_delete_post( $match1, true );
+		wp_delete_post( $match2, true );
+		wp_delete_post( $match3, true );
+	}
+
+	public function test_lineup_player_not_counted_as_sub() {
+		$match_id = $this->create_match( array(
+			'lineup' => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 2,
+				),
+			),
+			'subs'   => array(),
+		) );
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 0, $subs );
+
+		wp_delete_post( $match_id, true );
+	}
+
+	public function test_subs_total_returns_zero_with_no_matches() {
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 0, $subs );
+	}
+}

--- a/tests/wpunit/SubAppearancesTest.php
+++ b/tests/wpunit/SubAppearancesTest.php
@@ -20,6 +20,9 @@ class SubAppearancesTest extends WPCMTestCase {
 	/** @var int */
 	private $player_id;
 
+	/** @var int[] Match IDs created during tests. */
+	private $match_ids = array();
+
 	public function _setUp() {
 		parent::_setUp();
 
@@ -47,6 +50,11 @@ class SubAppearancesTest extends WPCMTestCase {
 	}
 
 	public function _tearDown() {
+		foreach ( $this->match_ids as $match_id ) {
+			wp_delete_post( $match_id, true );
+		}
+		$this->match_ids = array();
+
 		wp_delete_post( $this->player_id, true );
 		wp_delete_post( $this->club_id, true );
 		wp_delete_post( $this->away_club_id, true );
@@ -58,7 +66,7 @@ class SubAppearancesTest extends WPCMTestCase {
 	/**
 	 * Helper to create a match with player data.
 	 *
-	 * @param array $players Serialised wpcm_players structure.
+	 * @param array $players Array wpcm_players structure (serialised internally).
 	 * @return int Match post ID.
 	 */
 	private function create_match( $players ) {
@@ -73,6 +81,8 @@ class SubAppearancesTest extends WPCMTestCase {
 		update_post_meta( $match_id, 'wpcm_played', '1' );
 		update_post_meta( $match_id, 'wpcm_players', serialize( $players ) );
 
+		$this->match_ids[] = $match_id;
+
 		return $match_id;
 	}
 
@@ -81,7 +91,7 @@ class SubAppearancesTest extends WPCMTestCase {
 	// -------------------------------------------------------------------
 
 	public function test_checked_sub_is_counted() {
-		$match_id = $this->create_match( array(
+		$this->create_match( array(
 			'lineup' => array(),
 			'subs'   => array(
 				$this->player_id => array(
@@ -95,13 +105,11 @@ class SubAppearancesTest extends WPCMTestCase {
 		$subs = get_player_subs_total( $this->player_id );
 
 		$this->assertEquals( 1, $subs );
-
-		wp_delete_post( $match_id, true );
 	}
 
 	public function test_unchecked_sub_is_not_counted() {
 		// Legacy data: player in subs array but without 'checked' key.
-		$match_id = $this->create_match( array(
+		$this->create_match( array(
 			'lineup' => array(),
 			'subs'   => array(
 				$this->player_id => array(
@@ -114,13 +122,11 @@ class SubAppearancesTest extends WPCMTestCase {
 		$subs = get_player_subs_total( $this->player_id );
 
 		$this->assertEquals( 0, $subs, 'Unchecked sub should not be counted' );
-
-		wp_delete_post( $match_id, true );
 	}
 
 	public function test_multiple_matches_count_only_checked_subs() {
 		// Match 1: player is a checked sub.
-		$match1 = $this->create_match( array(
+		$this->create_match( array(
 			'lineup' => array(),
 			'subs'   => array(
 				$this->player_id => array(
@@ -131,7 +137,7 @@ class SubAppearancesTest extends WPCMTestCase {
 		) );
 
 		// Match 2: player is in subs but NOT checked (legacy data).
-		$match2 = $this->create_match( array(
+		$this->create_match( array(
 			'lineup' => array(),
 			'subs'   => array(
 				$this->player_id => array(
@@ -141,7 +147,7 @@ class SubAppearancesTest extends WPCMTestCase {
 		) );
 
 		// Match 3: player is a checked sub.
-		$match3 = $this->create_match( array(
+		$this->create_match( array(
 			'lineup' => array(),
 			'subs'   => array(
 				$this->player_id => array(
@@ -154,14 +160,10 @@ class SubAppearancesTest extends WPCMTestCase {
 		$subs = get_player_subs_total( $this->player_id );
 
 		$this->assertEquals( 2, $subs, 'Only checked subs should be counted' );
-
-		wp_delete_post( $match1, true );
-		wp_delete_post( $match2, true );
-		wp_delete_post( $match3, true );
 	}
 
 	public function test_lineup_player_not_counted_as_sub() {
-		$match_id = $this->create_match( array(
+		$this->create_match( array(
 			'lineup' => array(
 				$this->player_id => array(
 					'checked' => '1',
@@ -174,8 +176,6 @@ class SubAppearancesTest extends WPCMTestCase {
 		$subs = get_player_subs_total( $this->player_id );
 
 		$this->assertEquals( 0, $subs );
-
-		wp_delete_post( $match_id, true );
 	}
 
 	public function test_subs_total_returns_zero_with_no_matches() {


### PR DESCRIPTION
## Summary

- **`get_player_subs_total()`** now validates the `checked` key before counting a substitute appearance — legacy match data (pre-v2.3.0) could have unchecked subs in the serialised `wpcm_players` meta, inflating the sub count
- **`stats-table.php`** template uses `wp_kses()` with a strict allowlist (`span` + `class` only) instead of `esc_html()` for the sub appearances `<span>`, so the HTML renders correctly instead of being escaped as literal text
- **`unserialize()` → `maybe_unserialize()`** across all stats helpers in `wpcm-stats-functions.php` — prevents potential object-injection vectors and handles already-unserialized values safely (consistent with how other meta is read elsewhere in the codebase)

## Changes

| File | Change |
|------|--------|
| `includes/wpcm-stats-functions.php` | Add `checked` key validation in `get_player_subs_total()`; replace `unserialize()` with `maybe_unserialize()` in all stats helpers; add `is_array()` guard on `subs` key |
| `templates/single-player/stats-table.php` | Replace `esc_html()` with `wp_kses()` (strict allowlist) for sub display; cast count with `absint()` |
| `tests/wpunit/SubAppearancesTest.php` | New test class with 5 tests for sub appearance counting |

## Test plan

- [ ] WPUnit: `SubAppearancesTest` — validates checked/unchecked sub counting
- [ ] Manual: view player profile with sub appearances enabled, verify count is correct
- [ ] Manual: verify sub count displays as `(2)` not `<span class="sub-appearances">(2)</span>`

Closes #83