### PR TITLE
Fix: PHP 8.x remaining fatal errors from null property access (#91)

### DIFF
--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -323,12 +323,12 @@ class WPCM_Admin_Dashboard {
 
 						foreach ( $clubs as $club ) {
 
-							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season );
+							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season->term_id );
 							$club->wpcm_stats = $auto_stats;
 							if ( array_key_exists( $club->ID, $manual_stats ) ) {
 								$club->wpcm_manual_stats = $manual_stats[ $club->ID ];
 								$club->wpcm_auto_stats   = $auto_stats;
-								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season, $manual_stats[ $club->ID ] );
+								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season->term_id, $manual_stats[ $club->ID ] );
 								$club->wpcm_stats        = $total_stats;
 							}
 						}
@@ -477,12 +477,12 @@ class WPCM_Admin_Dashboard {
 
 						foreach ( $clubs as $club ) {
 
-							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season );
+							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season->term_id );
 							$club->wpcm_stats = $auto_stats;
 							if ( array_key_exists( $club->ID, $manual_stats ) ) {
 								$club->wpcm_manual_stats = $manual_stats[ $club->ID ];
 								$club->wpcm_auto_stats   = $auto_stats;
-								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season, $manual_stats[ $club->ID ] );
+								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season->term_id, $manual_stats[ $club->ID ] );
 								$club->wpcm_stats        = $total_stats;
 							}
 						}

--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -32,9 +32,15 @@ class WPCM_Admin_Dashboard {
 					$default_club = get_default_club();
 					$team         = filter_input( INPUT_POST, 'team_select', FILTER_UNSAFE_RAW );
 					if ( $team ) {
-						$term      = get_term( $team, 'wpcm_team' );
-						$team_name = $term->name;
-						$team_slug = $term->slug;
+						$term = get_term( $team, 'wpcm_team' );
+						if ( $term && ! is_wp_error( $term ) ) {
+							$team_name = $term->name;
+							$team_slug = $term->slug;
+						} else {
+							$team      = null;
+							$team_name = null;
+							$team_slug = null;
+						}
 					} else {
 						$teams = get_terms( array(
 							'taxonomy'   => 'wpcm_team',
@@ -53,14 +59,19 @@ class WPCM_Admin_Dashboard {
 						}
 					}
 					// Setup
-					$seasons     = get_terms( array(
+					$seasons = get_terms( array(
 						'taxonomy'   => 'wpcm_season',
 						'meta_key'   => 'tax_position',
 						'orderby'    => 'tax_position',
 						'hide_empty' => false,
 					) );
-					$season      = $seasons[0];
-					$season_slug = $seasons[0]->slug;
+					if ( is_array( $seasons ) && ! empty( $seasons ) ) {
+						$season      = $seasons[0];
+						$season_slug = $seasons[0]->slug;
+					} else {
+						$season      = null;
+						$season_slug = '';
+					}
 
 					// Statistics
 					$args = array(
@@ -86,7 +97,7 @@ class WPCM_Admin_Dashboard {
 							'value' => 1,
 						),
 					);
-					if ( isset( $season ) ) {
+					if ( $season ) {
 						$args['tax_query'][] = array(
 							'taxonomy' => 'wpcm_season',
 							'terms'    => $season->term_id,
@@ -341,14 +352,19 @@ class WPCM_Admin_Dashboard {
 
 				} else {
 					// Setup
-					$seasons     = get_terms( array(
+					$seasons = get_terms( array(
 						'taxonomy'   => 'wpcm_season',
 						'meta_key'   => 'tax_position',
 						'orderby'    => 'tax_position',
 						'hide_empty' => false,
 					) );
-					$season      = $seasons[0];
-					$season_slug = $seasons[0]->slug;
+					if ( is_array( $seasons ) && ! empty( $seasons ) ) {
+						$season      = $seasons[0];
+						$season_slug = $seasons[0]->slug;
+					} else {
+						$season      = null;
+						$season_slug = '';
+					}
 
 					// Statistics
 					$args = array(
@@ -364,7 +380,7 @@ class WPCM_Admin_Dashboard {
 							'value' => 1,
 						),
 					);
-					if ( isset( $season ) ) {
+					if ( $season ) {
 						$args['tax_query'][] = array(
 							'taxonomy' => 'wpcm_season',
 							'terms'    => $season->term_id,
@@ -381,7 +397,7 @@ class WPCM_Admin_Dashboard {
 						'posts_per_page' => 4,
 					);
 
-					if ( isset( $season ) ) {
+					if ( $season ) {
 						$args['tax_query'][] = array(
 							'taxonomy' => 'wpcm_season',
 							'terms'    => $season->term_id,

--- a/includes/wpcm-core-functions.php
+++ b/includes/wpcm-core-functions.php
@@ -532,13 +532,22 @@ function get_the_seasons( $post ) {
  */
 function get_current_season() {
 
-	$seasons         = get_terms( array(
+	$seasons = get_terms( array(
 		'taxonomy'     => 'wpcm_season',
 		'meta_key'     => 'tax_position',
 		'meta_compare' => 'NUMERIC',
 		'orderby'      => 'meta_value_num',
 		'hide_empty'   => false,
 	) );
+
+	if ( is_wp_error( $seasons ) || empty( $seasons ) ) {
+		return array(
+			'id'   => 0,
+			'name' => '',
+			'slug' => '',
+		);
+	}
+
 	$season          = $seasons[0];
 	$current['id']   = $season->term_id;
 	$current['name'] = $season->name;

--- a/includes/wpcm-player-functions.php
+++ b/includes/wpcm-player-functions.php
@@ -182,14 +182,14 @@ function wpcm_get_player_stats_labels( $subs = false ) {
 	}
 
 	$labels = wpcm_get_preset_labels();
-	$output = false;
+	$output = array();
 	foreach ( $labels as $label => $value ) {
 		if ( get_option( 'wpcm_show_stats_' . $label ) === 'yes' ) {
 			$output[ $label ] = $value;
 		}
 	}
 
-	if ( is_array( $output ) ) {
+	if ( ! empty( $output ) ) {
 		$stats_labels = array_merge( $appearance_label, $output );
 	} else {
 		$stats_labels = $appearance_label;
@@ -208,13 +208,13 @@ function wpcm_get_player_all_labels() {
 	$appearance_labels = wpcm_get_appearance_and_subs_labels();
 
 	$labels = wpcm_get_preset_labels();
-	$output = false;
+	$output = array();
 	foreach ( $labels as $label => $value ) {
 		if ( get_option( 'wpcm_show_stats_' . $label ) === 'yes' ) {
 			$output[ $label ] = $value;
 		}
 	}
-	if ( is_array( $output ) ) {
+	if ( ! empty( $output ) ) {
 		$stats_labels = array_merge( wpcm_player_labels(), $appearance_labels, $output );
 	} else {
 		$stats_labels = $appearance_labels;
@@ -237,13 +237,13 @@ function wpcm_get_player_stats_names( $subs = false ) {
 		$appearance_label = wpcm_get_appearance_names();
 	}
 	$labels = wpcm_get_preset_labels( 'players', 'name' );
-	$output = false;
+	$output = array();
 	foreach ( $labels as $label => $value ) {
 		if ( get_option( 'wpcm_show_stats_' . $label ) === 'yes' ) {
 			$output[ $label ] = $value;
 		}
 	}
-	if ( is_array( $output ) ) {
+	if ( ! empty( $output ) ) {
 		$stats_labels = array_merge( $appearance_label, $output );
 	} else {
 		$stats_labels = $appearance_label;

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -26,14 +26,15 @@ function wpcm_get_preset_labels( $type = 'players', $format = 'label' ) {
 	$sport = get_option( 'wpcm_sport' );
 	$data  = wpcm_get_sport_presets();
 
-	if ( 'standings' === $type ) {
+	$stats = array();
+	if ( 'standings' === $type && isset( $data[ $sport ]['standings_columns'] ) ) {
 		$stats = $data[ $sport ]['standings_columns'];
-	} elseif ( 'players' === $type ) {
+	} elseif ( 'players' === $type && isset( $data[ $sport ]['stats_labels'] ) ) {
 		$stats = $data[ $sport ]['stats_labels'];
 	}
 
+	$output = array();
 	foreach ( $stats as $key => $value ) {
-
 		$output[ $key ] = $value[ $format ];
 	}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1887,16 +1887,11 @@ parameters:
 
 		-
 			message: "#^Variable \\$output might not be defined\\.$#"
-			count: 2
-			path: includes/wpcm-stats-functions.php
-
-		-
-			message: "#^Variable \\$season might not be defined\\.$#"
 			count: 1
 			path: includes/wpcm-stats-functions.php
 
 		-
-			message: "#^Variable \\$stats might not be defined\\.$#"
+			message: "#^Variable \\$season might not be defined\\.$#"
 			count: 1
 			path: includes/wpcm-stats-functions.php
 


### PR DESCRIPTION
## Summary
- Fixes remaining PHP 8.x fatal errors that cause critical errors on sites running PHP 8.0+ (reported in Help Scout ticket #24381)
- Guards `$seasons[0]` access in admin dashboard against empty `get_terms()` results
- Guards `get_term()` and `get_current_season()` returns against null/WP_Error
- Initializes `$output` as `array()` instead of `false` in player stat functions to avoid deprecated false-to-array conversion
- Adds `isset()` checks for sport preset data in `wpcm_get_preset_labels()`

## Context
v2.3.0 fixed the `array_merge()` null argument in `wpcm_get_player_all_names()` (#64), but several similar PHP 8.x incompatibilities remained. On PHP 8.0+, reading a property on `null` (e.g. `$null->slug`) is a fatal TypeError, whereas on PHP 7.x it was just a warning.

## Test plan
- [ ] Verify admin dashboard loads on PHP 8.3 with no seasons configured
- [ ] Verify admin dashboard loads on PHP 8.3 with no teams configured  
- [ ] Verify admin dashboard loads on PHP 8.3 with seasons and teams configured
- [ ] Verify `get_current_season()` returns gracefully when no seasons exist
- [ ] Verify player stats widgets render without errors on PHP 8.3
- [ ] Run PHPCS, PHPStan, and WPUnit CI checks