### PR TITLE
[Fix] PHP 8.x fatal errors from null property access (#91)

### DIFF
--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -32,9 +32,15 @@ class WPCM_Admin_Dashboard {
 					$default_club = get_default_club();
 					$team         = filter_input( INPUT_POST, 'team_select', FILTER_UNSAFE_RAW );
 					if ( $team ) {
-						$term      = get_term( $team, 'wpcm_team' );
-						$team_name = $term->name;
-						$team_slug = $term->slug;
+						$term = get_term( $team, 'wpcm_team' );
+						if ( $term && ! is_wp_error( $term ) ) {
+							$team_name = $term->name;
+							$team_slug = $term->slug;
+						} else {
+							$team      = null;
+							$team_name = null;
+							$team_slug = null;
+						}
 					} else {
 						$teams = get_terms( array(
 							'taxonomy'   => 'wpcm_team',
@@ -53,14 +59,19 @@ class WPCM_Admin_Dashboard {
 						}
 					}
 					// Setup
-					$seasons     = get_terms( array(
+					$seasons = get_terms( array(
 						'taxonomy'   => 'wpcm_season',
 						'meta_key'   => 'tax_position',
 						'orderby'    => 'tax_position',
 						'hide_empty' => false,
 					) );
-					$season      = $seasons[0];
-					$season_slug = $seasons[0]->slug;
+					if ( is_array( $seasons ) && ! empty( $seasons ) ) {
+						$season      = $seasons[0];
+						$season_slug = $seasons[0]->slug;
+					} else {
+						$season      = null;
+						$season_slug = '';
+					}
 
 					// Statistics
 					$args = array(
@@ -341,14 +352,19 @@ class WPCM_Admin_Dashboard {
 
 				} else {
 					// Setup
-					$seasons     = get_terms( array(
+					$seasons = get_terms( array(
 						'taxonomy'   => 'wpcm_season',
 						'meta_key'   => 'tax_position',
 						'orderby'    => 'tax_position',
 						'hide_empty' => false,
 					) );
-					$season      = $seasons[0];
-					$season_slug = $seasons[0]->slug;
+					if ( is_array( $seasons ) && ! empty( $seasons ) ) {
+						$season      = $seasons[0];
+						$season_slug = $seasons[0]->slug;
+					} else {
+						$season      = null;
+						$season_slug = '';
+					}
 
 					// Statistics
 					$args = array(

--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -70,9 +70,9 @@ class WPCM_Admin_Dashboard {
 						<div class="ui warning message">
 							<div class="header"><?php esc_html_e( 'No seasons found.', 'wp-club-manager' ); ?></div>
 						</div>
-					</div>
-				</div>
-				<?php
+						</div>
+						</div>
+						<?php
 						return;
 					}
 
@@ -103,13 +103,11 @@ class WPCM_Admin_Dashboard {
 							'value' => 1,
 						),
 					);
-					if ( isset( $season ) ) {
-						$args['tax_query'][] = array(
-							'taxonomy' => 'wpcm_season',
-							'terms'    => $season->term_id,
-							'field'    => 'term_id',
-						);
-					}
+					$args['tax_query'][] = array(
+						'taxonomy' => 'wpcm_season',
+						'terms'    => $season->term_id,
+						'field'    => 'term_id',
+					);
 					if ( isset( $team ) ) {
 						$args['tax_query'][] = array(
 							'taxonomy' => 'wpcm_team',
@@ -179,13 +177,11 @@ class WPCM_Admin_Dashboard {
 							'value' => $default_club,
 						),
 					);
-					if ( isset( $season ) ) {
-						$args['tax_query'][] = array(
-							'taxonomy' => 'wpcm_season',
-							'terms'    => $season->term_id,
-							'field'    => 'term_id',
-						);
-					}
+					$args['tax_query'][] = array(
+						'taxonomy' => 'wpcm_season',
+						'terms'    => $season->term_id,
+						'field'    => 'term_id',
+					);
 					if ( isset( $team ) ) {
 						$args['tax_query'][] = array(
 							'taxonomy' => 'wpcm_team',
@@ -326,7 +322,7 @@ class WPCM_Admin_Dashboard {
 						$clubs = get_posts( $args );
 
 						$size      = count( $clubs );
-						$season_id = $season ? $season->term_id : null;
+						$season_id = $season->term_id;
 
 						foreach ( $clubs as $club ) {
 
@@ -370,9 +366,9 @@ class WPCM_Admin_Dashboard {
 						<div class="ui warning message">
 							<div class="header"><?php esc_html_e( 'No seasons found.', 'wp-club-manager' ); ?></div>
 						</div>
-					</div>
-				</div>
-				<?php
+						</div>
+						</div>
+						<?php
 						return;
 					}
 
@@ -393,13 +389,11 @@ class WPCM_Admin_Dashboard {
 							'value' => 1,
 						),
 					);
-					if ( isset( $season ) ) {
-						$args['tax_query'][] = array(
-							'taxonomy' => 'wpcm_season',
-							'terms'    => $season->term_id,
-							'field'    => 'term_id',
-						);
-					}
+					$args['tax_query'][] = array(
+						'taxonomy' => 'wpcm_season',
+						'terms'    => $season->term_id,
+						'field'    => 'term_id',
+					);
 
 					// Matches
 					$args = array(
@@ -410,13 +404,11 @@ class WPCM_Admin_Dashboard {
 						'posts_per_page' => 4,
 					);
 
-					if ( isset( $season ) ) {
-						$args['tax_query'][] = array(
-							'taxonomy' => 'wpcm_season',
-							'terms'    => $season->term_id,
-							'field'    => 'term_id',
-						);
-					}
+					$args['tax_query'][] = array(
+						'taxonomy' => 'wpcm_season',
+						'terms'    => $season->term_id,
+						'field'    => 'term_id',
+					);
 
 					$publish        = array(
 						'post_status' => 'publish',
@@ -487,7 +479,7 @@ class WPCM_Admin_Dashboard {
 						$clubs = get_posts( $args );
 
 						$size      = count( $clubs );
-						$season_id = $season ? $season->term_id : null;
+						$season_id = $season->term_id;
 
 						foreach ( $clubs as $club ) {
 

--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -65,13 +65,19 @@ class WPCM_Admin_Dashboard {
 						'orderby'    => 'tax_position',
 						'hide_empty' => false,
 					) );
-					if ( is_array( $seasons ) && ! empty( $seasons ) ) {
-						$season      = $seasons[0];
-						$season_slug = $seasons[0]->slug;
-					} else {
-						$season      = null;
-						$season_slug = '';
+					if ( is_wp_error( $seasons ) || ! is_array( $seasons ) || empty( $seasons ) ) {
+						?>
+						<div class="ui warning message">
+							<div class="header"><?php esc_html_e( 'No seasons found.', 'wp-club-manager' ); ?></div>
+						</div>
+					</div>
+				</div>
+				<?php
+						return;
 					}
+
+					$season      = $seasons[0];
+					$season_slug = $season->slug;
 
 					// Statistics
 					$args = array(
@@ -359,13 +365,19 @@ class WPCM_Admin_Dashboard {
 						'orderby'    => 'tax_position',
 						'hide_empty' => false,
 					) );
-					if ( is_array( $seasons ) && ! empty( $seasons ) ) {
-						$season      = $seasons[0];
-						$season_slug = $seasons[0]->slug;
-					} else {
-						$season      = null;
-						$season_slug = '';
+					if ( is_wp_error( $seasons ) || ! is_array( $seasons ) || empty( $seasons ) ) {
+						?>
+						<div class="ui warning message">
+							<div class="header"><?php esc_html_e( 'No seasons found.', 'wp-club-manager' ); ?></div>
+						</div>
+					</div>
+				</div>
+				<?php
+						return;
 					}
+
+					$season      = $seasons[0];
+					$season_slug = $season->slug;
 
 					// Statistics
 					$args = array(

--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -319,16 +319,17 @@ class WPCM_Admin_Dashboard {
 						);
 						$clubs = get_posts( $args );
 
-						$size = count( $clubs );
+						$size      = count( $clubs );
+						$season_id = $season ? $season->term_id : null;
 
 						foreach ( $clubs as $club ) {
 
-							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season );
+							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season_id );
 							$club->wpcm_stats = $auto_stats;
 							if ( array_key_exists( $club->ID, $manual_stats ) ) {
 								$club->wpcm_manual_stats = $manual_stats[ $club->ID ];
 								$club->wpcm_auto_stats   = $auto_stats;
-								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season, $manual_stats[ $club->ID ] );
+								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season_id, $manual_stats[ $club->ID ] );
 								$club->wpcm_stats        = $total_stats;
 							}
 						}
@@ -473,16 +474,17 @@ class WPCM_Admin_Dashboard {
 						);
 						$clubs = get_posts( $args );
 
-						$size = count( $clubs );
+						$size      = count( $clubs );
+						$season_id = $season ? $season->term_id : null;
 
 						foreach ( $clubs as $club ) {
 
-							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season );
+							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season_id );
 							$club->wpcm_stats = $auto_stats;
 							if ( array_key_exists( $club->ID, $manual_stats ) ) {
 								$club->wpcm_manual_stats = $manual_stats[ $club->ID ];
 								$club->wpcm_auto_stats   = $auto_stats;
-								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season, $manual_stats[ $club->ID ] );
+								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season_id, $manual_stats[ $club->ID ] );
 								$club->wpcm_stats        = $total_stats;
 							}
 						}

--- a/includes/wpcm-core-functions.php
+++ b/includes/wpcm-core-functions.php
@@ -532,13 +532,22 @@ function get_the_seasons( $post ) {
  */
 function get_current_season() {
 
-	$seasons         = get_terms( array(
+	$seasons = get_terms( array(
 		'taxonomy'     => 'wpcm_season',
 		'meta_key'     => 'tax_position',
 		'meta_compare' => 'NUMERIC',
 		'orderby'      => 'meta_value_num',
 		'hide_empty'   => false,
 	) );
+
+	if ( ! is_array( $seasons ) || empty( $seasons ) ) {
+		return array(
+			'id'   => null,
+			'name' => null,
+			'slug' => null,
+		);
+	}
+
 	$season          = $seasons[0];
 	$current['id']   = $season->term_id;
 	$current['name'] = $season->name;

--- a/includes/wpcm-player-functions.php
+++ b/includes/wpcm-player-functions.php
@@ -182,14 +182,14 @@ function wpcm_get_player_stats_labels( $subs = false ) {
 	}
 
 	$labels = wpcm_get_preset_labels();
-	$output = false;
+	$output = array();
 	foreach ( $labels as $label => $value ) {
 		if ( get_option( 'wpcm_show_stats_' . $label ) === 'yes' ) {
 			$output[ $label ] = $value;
 		}
 	}
 
-	if ( is_array( $output ) ) {
+	if ( ! empty( $output ) ) {
 		$stats_labels = array_merge( $appearance_label, $output );
 	} else {
 		$stats_labels = $appearance_label;
@@ -208,13 +208,13 @@ function wpcm_get_player_all_labels() {
 	$appearance_labels = wpcm_get_appearance_and_subs_labels();
 
 	$labels = wpcm_get_preset_labels();
-	$output = false;
+	$output = array();
 	foreach ( $labels as $label => $value ) {
 		if ( get_option( 'wpcm_show_stats_' . $label ) === 'yes' ) {
 			$output[ $label ] = $value;
 		}
 	}
-	if ( is_array( $output ) ) {
+	if ( ! empty( $output ) ) {
 		$stats_labels = array_merge( wpcm_player_labels(), $appearance_labels, $output );
 	} else {
 		$stats_labels = $appearance_labels;
@@ -237,13 +237,13 @@ function wpcm_get_player_stats_names( $subs = false ) {
 		$appearance_label = wpcm_get_appearance_names();
 	}
 	$labels = wpcm_get_preset_labels( 'players', 'name' );
-	$output = false;
+	$output = array();
 	foreach ( $labels as $label => $value ) {
 		if ( get_option( 'wpcm_show_stats_' . $label ) === 'yes' ) {
 			$output[ $label ] = $value;
 		}
 	}
-	if ( is_array( $output ) ) {
+	if ( ! empty( $output ) ) {
 		$stats_labels = array_merge( $appearance_label, $output );
 	} else {
 		$stats_labels = $appearance_label;

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -32,6 +32,7 @@ function wpcm_get_preset_labels( $type = 'players', $format = 'label' ) {
 		$stats = $data[ $sport ]['stats_labels'];
 	}
 
+	$output = array();
 	foreach ( $stats as $key => $value ) {
 
 		$output[ $key ] = $value[ $format ];
@@ -53,6 +54,7 @@ function wpcm_get_section_stats( $section = 'batting' ) {
 	$data  = wpcm_get_sport_presets();
 	$stats = $data[ $sport ]['stats_labels'];
 
+	$output = array();
 	foreach ( $stats as $key => $value ) {
 		if ( $section === $value['section'] ) {
 

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -56,7 +56,7 @@ function wpcm_get_section_stats( $section = 'batting' ) {
 
 	$output = array();
 	foreach ( $stats as $key => $value ) {
-		if ( $section === $value['section'] ) {
+		if ( isset( $value['section'] ) && $section === $value['section'] ) {
 
 			$output[ $key ] = $value['label'];
 		}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1886,11 +1886,6 @@ parameters:
 			path: includes/wpcm-stats-functions.php
 
 		-
-			message: "#^Variable \\$output might not be defined\\.$#"
-			count: 2
-			path: includes/wpcm-stats-functions.php
-
-		-
 			message: "#^Variable \\$season might not be defined\\.$#"
 			count: 1
 			path: includes/wpcm-stats-functions.php

--- a/tests/wpunit/Php8CompatTest.php
+++ b/tests/wpunit/Php8CompatTest.php
@@ -22,20 +22,22 @@ class Php8CompatTest extends WPCMTestCase {
 	// -----------------------------------------------------------------------
 
 	public function test_get_current_season_returns_empty_when_no_seasons() {
-		// Ensure no wpcm_season terms exist.
-		$terms = get_terms( array(
-			'taxonomy'   => 'wpcm_season',
-			'hide_empty' => false,
-			'fields'     => 'ids',
-		) );
-		$this->assertFalse( is_wp_error( $terms ), is_wp_error( $terms ) ? $terms->get_error_message() : '' );
-		if ( is_array( $terms ) ) {
-			foreach ( $terms as $term_id ) {
-				wp_delete_term( $term_id, 'wpcm_season' );
+		// Stub get_terms() for wpcm_season to return an empty array,
+		// avoiding state leakage from deleting real terms.
+		$filter = function ( $terms, $query ) {
+			if ( isset( $query->query_vars['taxonomy'] )
+				&& in_array( 'wpcm_season', (array) $query->query_vars['taxonomy'], true )
+			) {
+				return array();
 			}
-		}
+
+			return $terms;
+		};
+		add_filter( 'terms_pre_query', $filter, 10, 2 );
 
 		$result = get_current_season();
+
+		remove_filter( 'terms_pre_query', $filter, 10 );
 
 		$this->assertIsArray( $result );
 		$this->assertNull( $result['id'] );
@@ -56,16 +58,34 @@ class Php8CompatTest extends WPCMTestCase {
 		$this->assertFalse( is_wp_error( $term ), is_wp_error( $term ) ? $term->get_error_message() : '' );
 		$this->assertIsArray( $term );
 
-		update_term_meta( $term['term_id'], 'tax_position', 1 );
+		$term_id = $term['term_id'];
+
+		update_term_meta( $term_id, 'tax_position', 1 );
+
+		// Stub get_terms() so only our created term is returned,
+		// making the assertion deterministic regardless of other suite terms.
+		$term_obj = get_term( $term_id, 'wpcm_season' );
+		$filter   = function ( $terms, $query ) use ( $term_obj ) {
+			if ( isset( $query->query_vars['taxonomy'] )
+				&& in_array( 'wpcm_season', (array) $query->query_vars['taxonomy'], true )
+			) {
+				return array( $term_obj );
+			}
+
+			return $terms;
+		};
+		add_filter( 'terms_pre_query', $filter, 10, 2 );
 
 		$result = get_current_season();
 
+		remove_filter( 'terms_pre_query', $filter, 10 );
+
 		$this->assertIsArray( $result );
-		$this->assertEquals( $term['term_id'], $result['id'] );
+		$this->assertEquals( $term_id, $result['id'] );
 		$this->assertEquals( $season_name, $result['name'] );
 		$this->assertNotEmpty( $result['slug'] );
 
-		wp_delete_term( $term['term_id'], 'wpcm_season' );
+		wp_delete_term( $term_id, 'wpcm_season' );
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/wpunit/Php8CompatTest.php
+++ b/tests/wpunit/Php8CompatTest.php
@@ -28,6 +28,7 @@ class Php8CompatTest extends WPCMTestCase {
 			'hide_empty' => false,
 			'fields'     => 'ids',
 		) );
+		$this->assertFalse( is_wp_error( $terms ), is_wp_error( $terms ) ? $terms->get_error_message() : '' );
 		if ( is_array( $terms ) ) {
 			foreach ( $terms as $term_id ) {
 				wp_delete_term( $term_id, 'wpcm_season' );
@@ -43,14 +44,25 @@ class Php8CompatTest extends WPCMTestCase {
 	}
 
 	public function test_get_current_season_returns_data_when_season_exists() {
-		$term = wp_insert_term( 'Season 2024', 'wpcm_season' );
+		$season_name = 'Season 2024 ' . uniqid();
+		$term        = wp_insert_term(
+			$season_name,
+			'wpcm_season',
+			array(
+				'slug' => sanitize_title( $season_name ),
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $term ), is_wp_error( $term ) ? $term->get_error_message() : '' );
+		$this->assertIsArray( $term );
+
 		update_term_meta( $term['term_id'], 'tax_position', 1 );
 
 		$result = get_current_season();
 
 		$this->assertIsArray( $result );
 		$this->assertEquals( $term['term_id'], $result['id'] );
-		$this->assertEquals( 'Season 2024', $result['name'] );
+		$this->assertEquals( $season_name, $result['name'] );
 		$this->assertNotEmpty( $result['slug'] );
 
 		wp_delete_term( $term['term_id'], 'wpcm_season' );

--- a/tests/wpunit/Php8CompatTest.php
+++ b/tests/wpunit/Php8CompatTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for PHP 8.x compatibility fixes (#91).
+ *
+ * Covers null property access, uninitialized array variables,
+ * and false-to-array implicit conversion.
+ */
+
+class Php8CompatTest extends WPCMTestCase {
+
+	public function _setUp() {
+		parent::_setUp();
+		update_option( 'wpcm_sport', 'soccer' );
+	}
+
+	public function _tearDown() {
+		parent::_tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// get_current_season() — must not fatal when no seasons exist
+	// -----------------------------------------------------------------------
+
+	public function test_get_current_season_returns_empty_when_no_seasons() {
+		// Ensure no wpcm_season terms exist.
+		$terms = get_terms( array(
+			'taxonomy'   => 'wpcm_season',
+			'hide_empty' => false,
+			'fields'     => 'ids',
+		) );
+		if ( is_array( $terms ) ) {
+			foreach ( $terms as $term_id ) {
+				wp_delete_term( $term_id, 'wpcm_season' );
+			}
+		}
+
+		$result = get_current_season();
+
+		$this->assertIsArray( $result );
+		$this->assertNull( $result['id'] );
+		$this->assertNull( $result['name'] );
+		$this->assertNull( $result['slug'] );
+	}
+
+	public function test_get_current_season_returns_data_when_season_exists() {
+		$term = wp_insert_term( 'Season 2024', 'wpcm_season' );
+		update_term_meta( $term['term_id'], 'tax_position', 1 );
+
+		$result = get_current_season();
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( $term['term_id'], $result['id'] );
+		$this->assertEquals( 'Season 2024', $result['name'] );
+		$this->assertNotEmpty( $result['slug'] );
+
+		wp_delete_term( $term['term_id'], 'wpcm_season' );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_preset_labels() — $output must be initialized as array
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_preset_labels_returns_array_not_undefined() {
+		$result = wpcm_get_preset_labels( 'players', 'label' );
+		$this->assertIsArray( $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_section_stats() — $output must be initialized as array
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_section_stats_returns_array() {
+		// Use a section that likely has no stats to verify $output is initialized.
+		$result = wpcm_get_section_stats( 'nonexistent_section' );
+		$this->assertIsArray( $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_player_stats_labels() — $output = false then $output[$label]
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_player_stats_labels_no_fatal_when_no_stats_enabled() {
+		// Disable all stats to force $output to remain false / empty.
+		$labels = wpcm_get_preset_labels();
+		foreach ( $labels as $label => $value ) {
+			delete_option( 'wpcm_show_stats_' . $label );
+		}
+
+		$result = wpcm_get_player_stats_labels();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'appearances', $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_player_all_labels() — same $output = false pattern
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_player_all_labels_no_fatal_when_no_stats_enabled() {
+		$labels = wpcm_get_preset_labels();
+		foreach ( $labels as $label => $value ) {
+			delete_option( 'wpcm_show_stats_' . $label );
+		}
+
+		$result = wpcm_get_player_all_labels();
+		$this->assertIsArray( $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_player_stats_names() — same $output = false pattern
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_player_stats_names_no_fatal_when_no_stats_enabled() {
+		$labels = wpcm_get_preset_labels( 'players', 'name' );
+		foreach ( $labels as $label => $value ) {
+			delete_option( 'wpcm_show_stats_' . $label );
+		}
+
+		$result = wpcm_get_player_stats_names();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'appearances', $result );
+	}
+}


### PR DESCRIPTION
## Summary

- Guard `get_current_season()` against empty `$seasons` array — returns null values instead of fatal
- Guard admin dashboard `$seasons[0]->slug` access in both club and league mode branches
- Guard `get_term()` result with null/WP_Error check before property access
- Initialize `$output` as `array()` instead of `false` in `wpcm_get_player_stats_labels()`, `wpcm_get_player_all_labels()`, `wpcm_get_player_stats_names()` — prevents deprecated implicit false-to-array conversion
- Initialize `$output` as `array()` in `wpcm_get_preset_labels()` and `wpcm_get_section_stats()` — prevents undefined variable warning

## Changes

| File | Change |
|------|--------|
| `includes/wpcm-core-functions.php` | `get_current_season()` early return when no seasons exist |
| `includes/admin/class-wpcm-admin-dashboard.php` | Null guards on `$seasons[0]`, `get_term()` result |
| `includes/wpcm-player-functions.php` | `$output = false` → `$output = array()` in 3 functions |
| `includes/wpcm-stats-functions.php` | Initialize `$output = array()` in 2 functions |

## Test plan

- [ ] WPUnit: `Php8CompatTest` covers `get_current_season()` with and without seasons
- [ ] WPUnit: verifies `wpcm_get_player_stats_labels()`, `wpcm_get_player_all_labels()`, `wpcm_get_player_stats_names()` return arrays when no stats enabled
- [ ] WPUnit: verifies `wpcm_get_preset_labels()` and `wpcm_get_section_stats()` return arrays
- [ ] Manual: visit admin dashboard on fresh install with no seasons — no fatal error
- [ ] CI: PHPCS, PHPStan, PHPUnit all green

Closes #91