### PR TITLE
[Fix] Allow multiple players per user account (#100)

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-users.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-users.php
@@ -111,15 +111,14 @@ class WPCM_Meta_Box_Player_Users {
 		$user_id = filter_input( INPUT_POST, 'wpcm_link_users', FILTER_VALIDATE_INT );
 		if ( isset( $user_id ) ) {
 			$is_admin = self::has_administrator_role( $user_id );
-			update_post_meta( $post_id, '_wpcm_link_users', $user_id );
 
-			if ( ! $is_admin ) {
+			if ( ! $is_admin && $user_id > 0 ) {
 				wp_update_user( array(
 					'ID'   => $user_id,
 					'role' => 'player',
 				) );
 			}
-			update_user_meta( $user_id, '_linked_player', $post_id );
+			wpcm_link_player_to_user( $post_id, $user_id );
 		}
 
 		$email = filter_input( INPUT_POST, 'wpcm_create_user', FILTER_VALIDATE_EMAIL );
@@ -129,8 +128,9 @@ class WPCM_Meta_Box_Player_Users {
 				$player = sanitize_text_field( $create_username );
 			}
 			$new_user = wpcm_create_new_user( $email, $player );
-			update_user_meta( $new_user, '_linked_player', $post_id );
-			update_post_meta( $post_id, '_wpcm_link_users', $new_user );
+			if ( $new_user && ! is_wp_error( $new_user ) ) {
+				wpcm_link_player_to_user( $post_id, $new_user );
+			}
 		}
 
 		do_action( 'delete_plugin_transients' );

--- a/includes/wpcm-user-functions.php
+++ b/includes/wpcm-user-functions.php
@@ -101,6 +101,57 @@ function wpcm_create_new_user( $email, $username = '', $password = '' ) {
 }
 
 /**
+ * Get all player IDs linked to a WordPress user.
+ *
+ * Supports multiple players per user account (e.g. a parent
+ * managing children's profiles).
+ *
+ * @param int $user_id WordPress user ID.
+ * @return int[] Array of wpcm_player post IDs.
+ */
+function wpcm_get_linked_players( $user_id ) {
+	if ( empty( $user_id ) ) {
+		return array();
+	}
+
+	$values = get_user_meta( $user_id, '_linked_player', false );
+	return array_map( 'intval', array_filter( $values ) );
+}
+
+/**
+ * Link a player to a WordPress user account.
+ *
+ * Creates the bidirectional relationship between a wpcm_player post
+ * and a WP user.  Handles cleanup when the linked user changes and
+ * prevents duplicate entries so one user can manage many players.
+ *
+ * @param int $player_id The wpcm_player post ID.
+ * @param int $user_id   The WordPress user ID (0 to unlink).
+ */
+function wpcm_link_player_to_user( $player_id, $user_id ) {
+	$old_user_id = (int) get_post_meta( $player_id, '_wpcm_link_users', true );
+	$user_id     = (int) $user_id;
+
+	// Remove old user → player link when the user changes.
+	if ( $old_user_id && $old_user_id !== $user_id ) {
+		delete_user_meta( $old_user_id, '_linked_player', $player_id );
+	}
+
+	if ( $user_id > 0 ) {
+		update_post_meta( $player_id, '_wpcm_link_users', $user_id );
+
+		// Add user → player link only if it does not already exist.
+		$existing = wpcm_get_linked_players( $user_id );
+		if ( ! in_array( $player_id, $existing, true ) ) {
+			add_user_meta( $user_id, '_linked_player', $player_id );
+		}
+	} else {
+		// Unlinking — clear both sides.
+		delete_post_meta( $player_id, '_wpcm_link_users' );
+	}
+}
+
+/**
  * Modify the list of editable roles to prevent non-admin adding admin users.
  *
  * @param  array $roles

--- a/tests/wpunit/PlayerUserLinkTest.php
+++ b/tests/wpunit/PlayerUserLinkTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Tests for linking players to WordPress user accounts.
+ *
+ * Covers issue #100: allow multiple players per user account.
+ */
+
+class PlayerUserLinkTest extends WPCMTestCase {
+
+	/** @var int */
+	private $user_id;
+
+	/** @var int */
+	private $player_one;
+
+	/** @var int */
+	private $player_two;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		$this->user_id = $this->factory()->user->create( array(
+			'role' => 'player',
+		) );
+
+		$this->player_one = wp_insert_post( array(
+			'post_type'   => 'wpcm_player',
+			'post_title'  => 'Alice Smith',
+			'post_status' => 'publish',
+		) );
+
+		$this->player_two = wp_insert_post( array(
+			'post_type'   => 'wpcm_player',
+			'post_title'  => 'Bob Smith',
+			'post_status' => 'publish',
+		) );
+	}
+
+	public function _tearDown() {
+		wp_delete_post( $this->player_one, true );
+		wp_delete_post( $this->player_two, true );
+		wp_delete_user( $this->user_id );
+		parent::_tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_linked_players()
+	// -----------------------------------------------------------------------
+
+	public function test_get_linked_players_returns_empty_array_for_unlinked_user() {
+		$this->assertSame( array(), wpcm_get_linked_players( $this->user_id ) );
+	}
+
+	public function test_get_linked_players_returns_single_player() {
+		add_user_meta( $this->user_id, '_linked_player', $this->player_one );
+
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertSame( array( $this->player_one ), $linked );
+	}
+
+	public function test_get_linked_players_returns_multiple_players() {
+		add_user_meta( $this->user_id, '_linked_player', $this->player_one );
+		add_user_meta( $this->user_id, '_linked_player', $this->player_two );
+
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertCount( 2, $linked );
+		$this->assertContains( $this->player_one, $linked );
+		$this->assertContains( $this->player_two, $linked );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_link_player_to_user()
+	// -----------------------------------------------------------------------
+
+	public function test_link_player_to_user_creates_bidirectional_link() {
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+
+		$this->assertEquals( $this->user_id, get_post_meta( $this->player_one, '_wpcm_link_users', true ) );
+		$this->assertContains( $this->player_one, wpcm_get_linked_players( $this->user_id ) );
+	}
+
+	public function test_link_multiple_players_to_same_user() {
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+		wpcm_link_player_to_user( $this->player_two, $this->user_id );
+
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertCount( 2, $linked );
+		$this->assertContains( $this->player_one, $linked );
+		$this->assertContains( $this->player_two, $linked );
+	}
+
+	public function test_link_does_not_create_duplicate_entries() {
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertCount( 1, $linked );
+	}
+
+	public function test_changing_user_removes_old_user_link() {
+		$other_user = $this->factory()->user->create( array(
+			'role' => 'player',
+		) );
+
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+		wpcm_link_player_to_user( $this->player_one, $other_user );
+
+		// Old user should no longer have this player linked.
+		$this->assertNotContains( $this->player_one, wpcm_get_linked_players( $this->user_id ) );
+		// New user should have it.
+		$this->assertContains( $this->player_one, wpcm_get_linked_players( $other_user ) );
+
+		wp_delete_user( $other_user );
+	}
+
+	public function test_unlinking_user_removes_bidirectional_link() {
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+		wpcm_link_player_to_user( $this->player_two, $this->user_id );
+
+		// Unlink player one by setting user to 0 / none.
+		wpcm_link_player_to_user( $this->player_one, 0 );
+
+		$this->assertEquals( '', get_post_meta( $this->player_one, '_wpcm_link_users', true ) );
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertCount( 1, $linked );
+		$this->assertContains( $this->player_two, $linked );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `wpcm_get_linked_players()` helper to retrieve all player IDs linked to a WP user
- Adds `wpcm_link_player_to_user()` helper that manages the bidirectional player↔user relationship with duplicate prevention and cleanup on user change
- Updates `WPCM_Meta_Box_Player_Users::save()` to use the new helper instead of raw `update_user_meta()`, which previously overwrote the link and limited each user to one player

Closes #100

## Changes

| File | Change |
|------|--------|
| `includes/wpcm-user-functions.php` | Add `wpcm_get_linked_players()` and `wpcm_link_player_to_user()` |
| `includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-users.php` | Refactor save to use `wpcm_link_player_to_user()` |
| `tests/wpunit/PlayerUserLinkTest.php` | New test class covering multi-player linking, deduplication, unlinking, and user change cleanup |

## Test plan

- [ ] Link User A to Player 1 via the player edit screen → verify `_linked_player` meta is set on user
- [ ] Link User A to Player 2 via a different player edit screen → verify user now has both players linked
- [ ] Change Player 1's linked user from User A to User B → verify User A no longer has Player 1, User B does
- [ ] Set Player 2's linked user to "None" → verify both sides of the link are removed
- [ ] WPUnit tests pass in CI