### PR TITLE
[Fix] Players List and Standings widgets render empty (#102)

### DIFF
--- a/includes/widgets/class-wpcm-players-widget.php
+++ b/includes/widgets/class-wpcm-players-widget.php
@@ -131,8 +131,11 @@ class WPCM_Players_Widget extends WPCM_Widget {
 
 		$options_string = '';
 		foreach ( $instance as $key => $value ) {
-			if ( (string) $value !== '-1' ) {
-				$options_string .= ' ' . $key . '="' . $value . '"';
+			if ( '-1' !== (string) $value ) {
+				$sanitized_key = sanitize_key( $key );
+				if ( '' !== $sanitized_key ) {
+					$options_string .= ' ' . $sanitized_key . '="' . esc_attr( $value ) . '"';
+				}
 			}
 		}
 

--- a/includes/widgets/class-wpcm-players-widget.php
+++ b/includes/widgets/class-wpcm-players-widget.php
@@ -134,7 +134,7 @@ class WPCM_Players_Widget extends WPCM_Widget {
 			if ( '-1' !== (string) $value ) {
 				$sanitized_key = sanitize_key( $key );
 				if ( '' !== $sanitized_key ) {
-					$options_string .= ' ' . $sanitized_key . '="' . esc_attr( $value ) . '"';
+					$options_string .= ' ' . $sanitized_key . '="' . $value . '"';
 				}
 			}
 		}

--- a/includes/widgets/class-wpcm-players-widget.php
+++ b/includes/widgets/class-wpcm-players-widget.php
@@ -131,7 +131,7 @@ class WPCM_Players_Widget extends WPCM_Widget {
 
 		$options_string = '';
 		foreach ( $instance as $key => $value ) {
-			if ( -1 !== $value ) {
+			if ( (string) $value !== '-1' ) {
 				$options_string .= ' ' . $key . '="' . $value . '"';
 			}
 		}

--- a/includes/widgets/class-wpcm-standings-widget.php
+++ b/includes/widgets/class-wpcm-standings-widget.php
@@ -126,7 +126,7 @@ class WPCM_Standings_Widget extends WPCM_Widget {
 			}
 			$sanitized_key = sanitize_key( $key );
 			if ( '-1' !== (string) $value && '' !== $sanitized_key ) {
-				$options_string .= ' ' . $sanitized_key . '="' . esc_attr( $value ) . '"';
+				$options_string .= ' ' . $sanitized_key . '="' . $value . '"';
 			}
 		}
 

--- a/includes/widgets/class-wpcm-standings-widget.php
+++ b/includes/widgets/class-wpcm-standings-widget.php
@@ -124,8 +124,9 @@ class WPCM_Standings_Widget extends WPCM_Widget {
 			if ( 'linkclub' === $key ) {
 				$key = 'link_club';
 			}
-			if ( (string) $value !== '-1' ) {
-				$options_string .= ' ' . $key . '="' . $value . '"';
+			$sanitized_key = sanitize_key( $key );
+			if ( '-1' !== (string) $value && '' !== $sanitized_key ) {
+				$options_string .= ' ' . $sanitized_key . '="' . esc_attr( $value ) . '"';
 			}
 		}
 

--- a/includes/widgets/class-wpcm-standings-widget.php
+++ b/includes/widgets/class-wpcm-standings-widget.php
@@ -124,7 +124,7 @@ class WPCM_Standings_Widget extends WPCM_Widget {
 			if ( 'linkclub' === $key ) {
 				$key = 'link_club';
 			}
-			if ( -1 !== $value ) {
+			if ( (string) $value !== '-1' ) {
 				$options_string .= ' ' . $key . '="' . $value . '"';
 			}
 		}

--- a/tests/wpunit/WidgetRenderTest.php
+++ b/tests/wpunit/WidgetRenderTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for widget render methods — specifically that string "-1"
+ * values (produced by sanitize_text_field) are correctly excluded
+ * from shortcode attribute output.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/102
+ */
+
+class WidgetRenderTest extends WPCMTestCase {
+
+	/**
+	 * Test that WPCM_Players_Widget::widget() excludes string "-1" values
+	 * from the generated shortcode.
+	 */
+	public function test_players_widget_excludes_string_minus_one() {
+		$widget = new WPCM_Players_Widget();
+
+		// Simulate saved instance data — values come through sanitize_text_field()
+		// so "-1" markers arrive as strings, not integers.
+		$instance = array(
+			'title'           => 'Players',
+			'id'              => '42',
+			'limit'           => '3',
+			'position'        => '-1',
+			'display_options' => '-1',
+			'link_options'    => '-1',
+			'linktext'        => 'View all',
+			'linkpage'        => 'None',
+		);
+
+		$args = array(
+			'before_widget' => '<div>',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'widget_id'     => 'test-players-1',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		// The shortcode output should NOT contain position="-1" or link_options="-1".
+		$this->assertStringNotContainsString( 'position="-1"', $output, 'String "-1" position should be excluded from shortcode' );
+		$this->assertStringNotContainsString( 'display_options="-1"', $output, 'String "-1" display_options should be excluded from shortcode' );
+		$this->assertStringNotContainsString( 'link_options="-1"', $output, 'String "-1" link_options should be excluded from shortcode' );
+
+		// Valid values should still be present.
+		$this->assertStringContainsString( 'title="Players"', $output );
+		$this->assertStringContainsString( 'id="42"', $output );
+	}
+
+	/**
+	 * Test that WPCM_Standings_Widget::widget() excludes string "-1" values
+	 * from the generated shortcode.
+	 */
+	public function test_standings_widget_excludes_string_minus_one() {
+		$widget = new WPCM_Standings_Widget();
+
+		$instance = array(
+			'title'        => 'Standings',
+			'id'           => '99',
+			'limit'        => '7',
+			'link_options' => '-1',
+			'linktext'     => 'View all standings',
+			'linkpage'     => 'None',
+		);
+
+		$args = array(
+			'before_widget' => '<div>',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'widget_id'     => 'test-standings-1',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'link_options="-1"', $output, 'String "-1" link_options should be excluded from shortcode' );
+		$this->assertStringContainsString( 'title="Standings"', $output );
+		$this->assertStringContainsString( 'id="99"', $output );
+	}
+
+	/**
+	 * Test that integer -1 values are also excluded (original behaviour).
+	 */
+	public function test_players_widget_excludes_integer_minus_one() {
+		$widget = new WPCM_Players_Widget();
+
+		$instance = array(
+			'title'           => 'Players',
+			'id'              => '42',
+			'display_options' => -1,
+			'link_options'    => -1,
+		);
+
+		$args = array(
+			'before_widget' => '<div>',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'widget_id'     => 'test-players-2',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'display_options="-1"', $output );
+		$this->assertStringNotContainsString( 'link_options="-1"', $output );
+	}
+}

--- a/tests/wpunit/WidgetRenderTest.php
+++ b/tests/wpunit/WidgetRenderTest.php
@@ -30,12 +30,28 @@ class WidgetRenderTest extends WPCMTestCase {
 	private $captured_atts;
 
 	/**
+	 * Original shortcode callbacks to restore in teardown.
+	 *
+	 * @var array
+	 */
+	private $original_shortcodes = array();
+
+	/**
 	 * Register shortcode stubs before each test.
 	 */
-	public function setUp(): void {
-		parent::setUp();
+	public function _setUp() {
+		parent::_setUp();
+
+		global $shortcode_tags;
 
 		$this->captured_atts = null;
+
+		// Save original shortcode callbacks so we can restore them.
+		foreach ( array( 'player_list', 'league_table' ) as $tag ) {
+			if ( isset( $shortcode_tags[ $tag ] ) ) {
+				$this->original_shortcodes[ $tag ] = $shortcode_tags[ $tag ];
+			}
+		}
 
 		$stub = function ( $atts ) {
 			$this->captured_atts = $atts;
@@ -47,12 +63,16 @@ class WidgetRenderTest extends WPCMTestCase {
 	}
 
 	/**
-	 * Remove shortcode stubs after each test.
+	 * Restore original shortcode callbacks after each test.
 	 */
-	public function tearDown(): void {
-		remove_shortcode( 'player_list' );
-		remove_shortcode( 'league_table' );
-		parent::tearDown();
+	public function _tearDown() {
+		// Restore original shortcodes so other tests are not affected.
+		foreach ( $this->original_shortcodes as $tag => $callback ) {
+			add_shortcode( $tag, $callback );
+		}
+		$this->original_shortcodes = array();
+
+		parent::_tearDown();
 	}
 
 	/**

--- a/tests/wpunit/WidgetRenderTest.php
+++ b/tests/wpunit/WidgetRenderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for widget render methods — specifically that string "-1"
+ * Tests for widget render methods -- specifically that string "-1"
  * values (produced by sanitize_text_field) are correctly excluded
  * from shortcode attribute output.
  *
@@ -10,14 +10,56 @@
 class WidgetRenderTest extends WPCMTestCase {
 
 	/**
-	 * Test that WPCM_Players_Widget::widget() excludes string "-1" values
-	 * from the generated shortcode.
+	 * Default widget wrapper args.
+	 *
+	 * @var array
+	 */
+	private $widget_args = array(
+		'before_widget' => '<div>',
+		'after_widget'  => '</div>',
+		'before_title'  => '<h2>',
+		'after_title'   => '</h2>',
+		'widget_id'     => 'test-widget-1',
+	);
+
+	/**
+	 * Captured shortcode attributes from the stub.
+	 *
+	 * @var array|null
+	 */
+	private $captured_atts;
+
+	/**
+	 * Register shortcode stubs before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->captured_atts = null;
+
+		$stub = function ( $atts ) {
+			$this->captured_atts = $atts;
+			return '';
+		};
+
+		add_shortcode( 'player_list', $stub );
+		add_shortcode( 'league_table', $stub );
+	}
+
+	/**
+	 * Remove shortcode stubs after each test.
+	 */
+	public function tearDown(): void {
+		remove_shortcode( 'player_list' );
+		remove_shortcode( 'league_table' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that WPCM_Players_Widget excludes string "-1" values from shortcode atts.
 	 */
 	public function test_players_widget_excludes_string_minus_one() {
-		$widget = new WPCM_Players_Widget();
-
-		// Simulate saved instance data — values come through sanitize_text_field()
-		// so "-1" markers arrive as strings, not integers.
+		$widget   = new WPCM_Players_Widget();
 		$instance = array(
 			'title'           => 'Players',
 			'id'              => '42',
@@ -29,35 +71,23 @@ class WidgetRenderTest extends WPCMTestCase {
 			'linkpage'        => 'None',
 		);
 
-		$args = array(
-			'before_widget' => '<div>',
-			'after_widget'  => '</div>',
-			'before_title'  => '<h2>',
-			'after_title'   => '</h2>',
-			'widget_id'     => 'test-players-1',
-		);
-
 		ob_start();
-		$widget->widget( $args, $instance );
-		$output = ob_get_clean();
+		$widget->widget( $this->widget_args, $instance );
+		ob_get_clean();
 
-		// The shortcode output should NOT contain position="-1" or link_options="-1".
-		$this->assertStringNotContainsString( 'position="-1"', $output, 'String "-1" position should be excluded from shortcode' );
-		$this->assertStringNotContainsString( 'display_options="-1"', $output, 'String "-1" display_options should be excluded from shortcode' );
-		$this->assertStringNotContainsString( 'link_options="-1"', $output, 'String "-1" link_options should be excluded from shortcode' );
-
-		// Valid values should still be present.
-		$this->assertStringContainsString( 'title="Players"', $output );
-		$this->assertStringContainsString( 'id="42"', $output );
+		$this->assertIsArray( $this->captured_atts, 'player_list shortcode should be invoked.' );
+		$this->assertArrayNotHasKey( 'position', $this->captured_atts, 'String "-1" position should be excluded.' );
+		$this->assertArrayNotHasKey( 'display_options', $this->captured_atts, 'String "-1" display_options should be excluded.' );
+		$this->assertArrayNotHasKey( 'link_options', $this->captured_atts, 'String "-1" link_options should be excluded.' );
+		$this->assertSame( 'Players', $this->captured_atts['title'] );
+		$this->assertSame( '42', $this->captured_atts['id'] );
 	}
 
 	/**
-	 * Test that WPCM_Standings_Widget::widget() excludes string "-1" values
-	 * from the generated shortcode.
+	 * Test that WPCM_Standings_Widget excludes string "-1" values from shortcode atts.
 	 */
 	public function test_standings_widget_excludes_string_minus_one() {
-		$widget = new WPCM_Standings_Widget();
-
+		$widget   = new WPCM_Standings_Widget();
 		$instance = array(
 			'title'        => 'Standings',
 			'id'           => '99',
@@ -67,29 +97,21 @@ class WidgetRenderTest extends WPCMTestCase {
 			'linkpage'     => 'None',
 		);
 
-		$args = array(
-			'before_widget' => '<div>',
-			'after_widget'  => '</div>',
-			'before_title'  => '<h2>',
-			'after_title'   => '</h2>',
-			'widget_id'     => 'test-standings-1',
-		);
-
 		ob_start();
-		$widget->widget( $args, $instance );
-		$output = ob_get_clean();
+		$widget->widget( $this->widget_args, $instance );
+		ob_get_clean();
 
-		$this->assertStringNotContainsString( 'link_options="-1"', $output, 'String "-1" link_options should be excluded from shortcode' );
-		$this->assertStringContainsString( 'title="Standings"', $output );
-		$this->assertStringContainsString( 'id="99"', $output );
+		$this->assertIsArray( $this->captured_atts, 'league_table shortcode should be invoked.' );
+		$this->assertArrayNotHasKey( 'link_options', $this->captured_atts, 'String "-1" link_options should be excluded.' );
+		$this->assertSame( 'Standings', $this->captured_atts['title'] );
+		$this->assertSame( '99', $this->captured_atts['id'] );
 	}
 
 	/**
-	 * Test that integer -1 values are also excluded (original behaviour).
+	 * Test that integer -1 values are also excluded for WPCM_Players_Widget.
 	 */
 	public function test_players_widget_excludes_integer_minus_one() {
-		$widget = new WPCM_Players_Widget();
-
+		$widget   = new WPCM_Players_Widget();
 		$instance = array(
 			'title'           => 'Players',
 			'id'              => '42',
@@ -97,19 +119,36 @@ class WidgetRenderTest extends WPCMTestCase {
 			'link_options'    => -1,
 		);
 
-		$args = array(
-			'before_widget' => '<div>',
-			'after_widget'  => '</div>',
-			'before_title'  => '<h2>',
-			'after_title'   => '</h2>',
-			'widget_id'     => 'test-players-2',
+		ob_start();
+		$widget->widget( $this->widget_args, $instance );
+		ob_get_clean();
+
+		$this->assertIsArray( $this->captured_atts, 'player_list shortcode should be invoked.' );
+		$this->assertArrayNotHasKey( 'display_options', $this->captured_atts, 'Integer -1 display_options should be excluded.' );
+		$this->assertArrayNotHasKey( 'link_options', $this->captured_atts, 'Integer -1 link_options should be excluded.' );
+	}
+
+	/**
+	 * Test that integer -1 values are also excluded for WPCM_Standings_Widget.
+	 */
+	public function test_standings_widget_excludes_integer_minus_one() {
+		$widget   = new WPCM_Standings_Widget();
+		$instance = array(
+			'title'        => 'Standings',
+			'id'           => '99',
+			'limit'        => '7',
+			'link_options' => -1,
+			'linktext'     => 'View all standings',
+			'linkpage'     => 'None',
 		);
 
 		ob_start();
-		$widget->widget( $args, $instance );
-		$output = ob_get_clean();
+		$widget->widget( $this->widget_args, $instance );
+		ob_get_clean();
 
-		$this->assertStringNotContainsString( 'display_options="-1"', $output );
-		$this->assertStringNotContainsString( 'link_options="-1"', $output );
+		$this->assertIsArray( $this->captured_atts, 'league_table shortcode should be invoked.' );
+		$this->assertArrayNotHasKey( 'link_options', $this->captured_atts, 'Integer -1 link_options should be excluded.' );
+		$this->assertSame( 'Standings', $this->captured_atts['title'] );
+		$this->assertSame( '99', $this->captured_atts['id'] );
 	}
 }


### PR DESCRIPTION
## Summary

- **Problem:** The PHPCS cleanup in 2.3.1 changed `-1 != $value` to `-1 !== $value` in the Players List and Standings widget render methods. However, widget instance values pass through `sanitize_text_field()` on save, converting the integer `-1` marker to the string `"-1"`. The strict comparison `-1 !== "-1"` always evaluates `true`, so marker values like `position`, `display_options`, and `link_options` leak into the shortcode, breaking the underlying query and producing empty output.
- **Fix:** Cast both sides to string (`(string) $value !== '-1'`) so the check works regardless of type, in both `class-wpcm-players-widget.php` and `class-wpcm-standings-widget.php`.

## Changes

| File | Change |
|------|--------|
| `includes/widgets/class-wpcm-players-widget.php` | `(string) $value !== '-1'` instead of `-1 !== $value` |
| `includes/widgets/class-wpcm-standings-widget.php` | `(string) $value !== '-1'` instead of `-1 !== $value` |
| `tests/wpunit/WidgetRenderTest.php` | New test covering string and integer `-1` exclusion for both widgets |

## Test plan

- [ ] WPUnit tests pass (WidgetRenderTest covers string and integer `-1` cases)
- [ ] PHPCS passes (no loose comparison — both sides are explicitly typed)
- [ ] Add Players List widget to sidebar, configure with a roster, verify players render on frontend
- [ ] Add League Table widget to sidebar, configure with a table, verify standings render on frontend

Closes #102