### PR TITLE
Fix: anchor vendor pattern in .distignore to preserve JS assets (#104)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,7 +4,7 @@
 .sass-cache
 node_modules
 tests
-vendor
+/vendor
 build
 release
 phpstan-stubs

--- a/tests/wpunit/DistIgnoreTest.php
+++ b/tests/wpunit/DistIgnoreTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for .distignore to prevent accidental exclusion of shipped assets.
+ */
+
+class DistIgnoreTest extends WPCMTestCase {
+
+	/**
+	 * The parsed lines from .distignore (comments and blanks stripped).
+	 *
+	 * @var string[]
+	 */
+	private $patterns;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		$distignore_path = dirname( __DIR__, 2 ) . '/.distignore';
+		$this->assertFileExists( $distignore_path, '.distignore must exist' );
+
+		$lines = file( $distignore_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
+		$this->patterns = array_filter(
+			$lines,
+			function ( $line ) {
+				return '' !== trim( $line ) && '#' !== $line[0];
+			}
+		);
+	}
+
+	/**
+	 * Vendor JS assets must not be excluded by .distignore.
+	 *
+	 * The "vendor" pattern in .distignore is intended to exclude the
+	 * top-level Composer vendor/ directory. If it is not anchored with
+	 * a leading slash, rsync will also exclude assets/js/vendor/ which
+	 * ships required libraries (Chosen, Timepicker, etc.).
+	 *
+	 * @see https://github.com/WPClubManager/wp-club-manager/issues/104
+	 */
+	public function test_vendor_pattern_is_anchored_to_root() {
+		foreach ( $this->patterns as $pattern ) {
+			$trimmed = trim( $pattern );
+
+			// Skip anything that isn't about the word "vendor".
+			if ( false === strpos( $trimmed, 'vendor' ) ) {
+				continue;
+			}
+
+			// An unanchored "vendor" (no leading slash) would match
+			// assets/js/vendor/ and break the build.
+			$this->assertStringStartsWith(
+				'/',
+				$trimmed,
+				sprintf(
+					'.distignore pattern "%s" is not anchored — it will exclude assets/js/vendor/. Use "/%s" instead.',
+					$trimmed,
+					ltrim( $trimmed, '/' )
+				)
+			);
+		}
+	}
+
+	/**
+	 * All four vendor JS files referenced by the admin scripts must exist.
+	 */
+	public function test_required_vendor_js_files_exist() {
+		$plugin_dir = dirname( __DIR__, 2 );
+
+		$required_files = array(
+			'assets/js/vendor/jquery-chosen/chosen.jquery.min.js',
+			'assets/js/vendor/jquery-chosen/chosen.order.jquery.min.js',
+			'assets/js/vendor/jquery-chosen/ajax-chosen.jquery.min.js',
+			'assets/js/vendor/jquery.timepicker.min.js',
+		);
+
+		foreach ( $required_files as $file ) {
+			$this->assertFileExists(
+				$plugin_dir . '/' . $file,
+				sprintf( 'Required vendor JS file missing: %s', $file )
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- The unanchored `vendor` pattern in `.distignore` matched `assets/js/vendor/` during SVN deploy, stripping Chosen and Timepicker JS libraries from the 2.3.1 WordPress.org release
- Anchors the pattern to `/vendor` so only the top-level Composer directory is excluded
- Adds regression test to ensure `.distignore` vendor patterns stay root-anchored

## Changes

| File | Change |
|------|--------|
| `.distignore` | `vendor` → `/vendor` (anchor to root) |
| `tests/wpunit/DistIgnoreTest.php` | New test: vendor pattern anchoring + required vendor JS files exist |

## Root cause

Commit 7e34745 ("Fix: exclude dev files from Grunt build") was not the direct cause — the `vendor` entry in `.distignore` predates it. However, `.distignore` was expanded in that release cycle, and the unanchored `vendor` pattern has always been a latent bug that became visible when the SVN deploy ran for 2.3.1.

In rsync (used by the WordPress.org deploy action), an unanchored pattern like `vendor` matches at any depth, so `assets/js/vendor/` was excluded alongside the intended `vendor/` (Composer).

## Test plan

- [ ] CI: WPUnit test `DistIgnoreTest::test_vendor_pattern_is_anchored_to_root` passes
- [ ] CI: WPUnit test `DistIgnoreTest::test_required_vendor_js_files_exist` passes
- [ ] CI: PHPCS clean
- [ ] Manual: `grunt build` produces a ZIP containing `assets/js/vendor/jquery-chosen/` and `assets/js/vendor/jquery.timepicker.min.js`

Closes #104