### PR TITLE
[Fix] PHP 8.x fatal error: array_merge null argument in settings (#108)

### DIFF
--- a/includes/wpcm-player-functions.php
+++ b/includes/wpcm-player-functions.php
@@ -158,7 +158,7 @@ function wpcm_get_appearance_names() {
  */
 function wpcm_get_appearance_and_subs_names() {
 
-	$apps        = wpcm_get_appearance_names();
+	$apps        = (array) wpcm_get_appearance_names();
 	$subs        = array(
 		'subs' => __( 'Sub Appearances', 'wp-club-manager' ),
 	);

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -26,16 +26,20 @@ function wpcm_get_preset_labels( $type = 'players', $format = 'label' ) {
 	$sport = get_option( 'wpcm_sport' );
 	$data  = wpcm_get_sport_presets();
 
-	if ( 'standings' === $type ) {
-		$stats = $data[ $sport ]['standings_columns'];
-	} elseif ( 'players' === $type ) {
-		$stats = $data[ $sport ]['stats_labels'];
+	$stats = array();
+	if ( $sport && isset( $data[ $sport ] ) ) {
+		if ( 'standings' === $type && isset( $data[ $sport ]['standings_columns'] ) ) {
+			$stats = $data[ $sport ]['standings_columns'];
+		} elseif ( 'players' === $type && isset( $data[ $sport ]['stats_labels'] ) ) {
+			$stats = $data[ $sport ]['stats_labels'];
+		}
 	}
 
 	$output = array();
 	foreach ( $stats as $key => $value ) {
-
-		$output[ $key ] = $value[ $format ];
+		if ( isset( $value[ $format ] ) ) {
+			$output[ $key ] = $value[ $format ];
+		}
 	}
 
 	return $output;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1771,11 +1771,6 @@ parameters:
 			path: includes/wpcm-stats-functions.php
 
 		-
-			message: "#^Variable \\$stats might not be defined\\.$#"
-			count: 1
-			path: includes/wpcm-stats-functions.php
-
-		-
 			message: "#^Variable \\$team might not be defined\\.$#"
 			count: 1
 			path: includes/wpcm-stats-functions.php

--- a/tests/wpunit/Php8CompatTest.php
+++ b/tests/wpunit/Php8CompatTest.php
@@ -97,6 +97,32 @@ class Php8CompatTest extends WPCMTestCase {
 		$this->assertIsArray( $result );
 	}
 
+	public function test_wpcm_get_preset_labels_returns_empty_array_when_sport_missing() {
+		delete_option( 'wpcm_sport' );
+
+		$result = wpcm_get_preset_labels( 'players', 'label' );
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+
+		// Restore for subsequent tests.
+		update_option( 'wpcm_sport', 'soccer' );
+	}
+
+	public function test_wpcm_get_preset_labels_returns_empty_array_when_sport_unknown() {
+		update_option( 'wpcm_sport', 'nonexistent_sport' );
+
+		$result = wpcm_get_preset_labels( 'players', 'label' );
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+
+		$standings = wpcm_get_preset_labels( 'standings', 'label' );
+		$this->assertIsArray( $standings );
+		$this->assertEmpty( $standings );
+
+		// Restore for subsequent tests.
+		update_option( 'wpcm_sport', 'soccer' );
+	}
+
 	// -----------------------------------------------------------------------
 	// wpcm_get_section_stats() — $output must be initialized as array
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes PHP 8.x `TypeError: array_merge(): Argument #2 must be of type array, null given` in `WPCM_Settings_Players::get_settings()` at line 170
- Root cause: `wpcm_get_preset_labels()` accesses undefined array keys when `wpcm_sport` option is missing/invalid, causing a fatal error before returning
- Also guards `wpcm_get_appearance_and_subs_names()` against null filter returns

## Changes

| File | Change |
|------|--------|
| `includes/wpcm-stats-functions.php` | Add `isset()` guards for sport key, type key, and format key in `wpcm_get_preset_labels()` |
| `includes/wpcm-player-functions.php` | Cast `wpcm_get_appearance_names()` filter result to `(array)` to prevent null reaching `array_merge()` |

Closes #108

## Test plan

- [ ] Activate plugin on PHP 8.3 with no `wpcm_sport` option set - should not fatal
- [ ] Activate plugin on PHP 8.3 with valid sport option - settings page loads correctly
- [ ] Player stats display correctly on admin edit screen
- [ ] CI: PHPCS, PHPStan, WPUnit, Playwright all green