### PR TITLE
Release 2.3.2

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,7 +4,7 @@
 .sass-cache
 node_modules
 tests
-vendor
+/vendor
 build
 release
 phpstan-stubs

--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -32,9 +32,15 @@ class WPCM_Admin_Dashboard {
 					$default_club = get_default_club();
 					$team         = filter_input( INPUT_POST, 'team_select', FILTER_UNSAFE_RAW );
 					if ( $team ) {
-						$term      = get_term( $team, 'wpcm_team' );
-						$team_name = $term->name;
-						$team_slug = $term->slug;
+						$term = get_term( $team, 'wpcm_team' );
+						if ( $term && ! is_wp_error( $term ) ) {
+							$team_name = $term->name;
+							$team_slug = $term->slug;
+						} else {
+							$team      = null;
+							$team_name = null;
+							$team_slug = null;
+						}
 					} else {
 						$teams = get_terms( array(
 							'taxonomy'   => 'wpcm_team',
@@ -53,14 +59,25 @@ class WPCM_Admin_Dashboard {
 						}
 					}
 					// Setup
-					$seasons     = get_terms( array(
+					$seasons = get_terms( array(
 						'taxonomy'   => 'wpcm_season',
 						'meta_key'   => 'tax_position',
 						'orderby'    => 'tax_position',
 						'hide_empty' => false,
 					) );
+					if ( is_wp_error( $seasons ) || ! is_array( $seasons ) || empty( $seasons ) ) {
+						?>
+						<div class="ui warning message">
+							<div class="header"><?php esc_html_e( 'No seasons found.', 'wp-club-manager' ); ?></div>
+						</div>
+						</div>
+						</div>
+						<?php
+						return;
+					}
+
 					$season      = $seasons[0];
-					$season_slug = $seasons[0]->slug;
+					$season_slug = $season->slug;
 
 					// Statistics
 					$args = array(
@@ -86,13 +103,11 @@ class WPCM_Admin_Dashboard {
 							'value' => 1,
 						),
 					);
-					if ( isset( $season ) ) {
-						$args['tax_query'][] = array(
-							'taxonomy' => 'wpcm_season',
-							'terms'    => $season->term_id,
-							'field'    => 'term_id',
-						);
-					}
+					$args['tax_query'][] = array(
+						'taxonomy' => 'wpcm_season',
+						'terms'    => $season->term_id,
+						'field'    => 'term_id',
+					);
 					if ( isset( $team ) ) {
 						$args['tax_query'][] = array(
 							'taxonomy' => 'wpcm_team',
@@ -162,13 +177,11 @@ class WPCM_Admin_Dashboard {
 							'value' => $default_club,
 						),
 					);
-					if ( isset( $season ) ) {
-						$args['tax_query'][] = array(
-							'taxonomy' => 'wpcm_season',
-							'terms'    => $season->term_id,
-							'field'    => 'term_id',
-						);
-					}
+					$args['tax_query'][] = array(
+						'taxonomy' => 'wpcm_season',
+						'terms'    => $season->term_id,
+						'field'    => 'term_id',
+					);
 					if ( isset( $team ) ) {
 						$args['tax_query'][] = array(
 							'taxonomy' => 'wpcm_team',
@@ -308,16 +321,17 @@ class WPCM_Admin_Dashboard {
 						);
 						$clubs = get_posts( $args );
 
-						$size = count( $clubs );
+						$size      = count( $clubs );
+						$season_id = $season->term_id;
 
 						foreach ( $clubs as $club ) {
 
-							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season );
+							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season_id );
 							$club->wpcm_stats = $auto_stats;
 							if ( array_key_exists( $club->ID, $manual_stats ) ) {
 								$club->wpcm_manual_stats = $manual_stats[ $club->ID ];
 								$club->wpcm_auto_stats   = $auto_stats;
-								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season, $manual_stats[ $club->ID ] );
+								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season_id, $manual_stats[ $club->ID ] );
 								$club->wpcm_stats        = $total_stats;
 							}
 						}
@@ -341,14 +355,25 @@ class WPCM_Admin_Dashboard {
 
 				} else {
 					// Setup
-					$seasons     = get_terms( array(
+					$seasons = get_terms( array(
 						'taxonomy'   => 'wpcm_season',
 						'meta_key'   => 'tax_position',
 						'orderby'    => 'tax_position',
 						'hide_empty' => false,
 					) );
+					if ( is_wp_error( $seasons ) || ! is_array( $seasons ) || empty( $seasons ) ) {
+						?>
+						<div class="ui warning message">
+							<div class="header"><?php esc_html_e( 'No seasons found.', 'wp-club-manager' ); ?></div>
+						</div>
+						</div>
+						</div>
+						<?php
+						return;
+					}
+
 					$season      = $seasons[0];
-					$season_slug = $seasons[0]->slug;
+					$season_slug = $season->slug;
 
 					// Statistics
 					$args = array(
@@ -364,13 +389,11 @@ class WPCM_Admin_Dashboard {
 							'value' => 1,
 						),
 					);
-					if ( isset( $season ) ) {
-						$args['tax_query'][] = array(
-							'taxonomy' => 'wpcm_season',
-							'terms'    => $season->term_id,
-							'field'    => 'term_id',
-						);
-					}
+					$args['tax_query'][] = array(
+						'taxonomy' => 'wpcm_season',
+						'terms'    => $season->term_id,
+						'field'    => 'term_id',
+					);
 
 					// Matches
 					$args = array(
@@ -381,13 +404,11 @@ class WPCM_Admin_Dashboard {
 						'posts_per_page' => 4,
 					);
 
-					if ( isset( $season ) ) {
-						$args['tax_query'][] = array(
-							'taxonomy' => 'wpcm_season',
-							'terms'    => $season->term_id,
-							'field'    => 'term_id',
-						);
-					}
+					$args['tax_query'][] = array(
+						'taxonomy' => 'wpcm_season',
+						'terms'    => $season->term_id,
+						'field'    => 'term_id',
+					);
 
 					$publish        = array(
 						'post_status' => 'publish',
@@ -457,16 +478,17 @@ class WPCM_Admin_Dashboard {
 						);
 						$clubs = get_posts( $args );
 
-						$size = count( $clubs );
+						$size      = count( $clubs );
+						$season_id = $season->term_id;
 
 						foreach ( $clubs as $club ) {
 
-							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season );
+							$auto_stats       = get_wpcm_club_auto_stats( $club->ID, $comp, $season_id );
 							$club->wpcm_stats = $auto_stats;
 							if ( array_key_exists( $club->ID, $manual_stats ) ) {
 								$club->wpcm_manual_stats = $manual_stats[ $club->ID ];
 								$club->wpcm_auto_stats   = $auto_stats;
-								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season, $manual_stats[ $club->ID ] );
+								$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season_id, $manual_stats[ $club->ID ] );
 								$club->wpcm_stats        = $total_stats;
 							}
 						}

--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-users.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-users.php
@@ -111,15 +111,14 @@ class WPCM_Meta_Box_Player_Users {
 		$user_id = filter_input( INPUT_POST, 'wpcm_link_users', FILTER_VALIDATE_INT );
 		if ( isset( $user_id ) ) {
 			$is_admin = self::has_administrator_role( $user_id );
-			update_post_meta( $post_id, '_wpcm_link_users', $user_id );
 
-			if ( ! $is_admin ) {
+			if ( ! $is_admin && $user_id > 0 ) {
 				wp_update_user( array(
 					'ID'   => $user_id,
 					'role' => 'player',
 				) );
 			}
-			update_user_meta( $user_id, '_linked_player', $post_id );
+			wpcm_link_player_to_user( $post_id, $user_id );
 		}
 
 		$email = filter_input( INPUT_POST, 'wpcm_create_user', FILTER_VALIDATE_EMAIL );
@@ -129,8 +128,9 @@ class WPCM_Meta_Box_Player_Users {
 				$player = sanitize_text_field( $create_username );
 			}
 			$new_user = wpcm_create_new_user( $email, $player );
-			update_user_meta( $new_user, '_linked_player', $post_id );
-			update_post_meta( $post_id, '_wpcm_link_users', $new_user );
+			if ( $new_user && ! is_wp_error( $new_user ) ) {
+				wpcm_link_player_to_user( $post_id, $new_user );
+			}
 		}
 
 		do_action( 'delete_plugin_transients' );

--- a/includes/widgets/class-wpcm-players-widget.php
+++ b/includes/widgets/class-wpcm-players-widget.php
@@ -131,8 +131,11 @@ class WPCM_Players_Widget extends WPCM_Widget {
 
 		$options_string = '';
 		foreach ( $instance as $key => $value ) {
-			if ( -1 !== $value ) {
-				$options_string .= ' ' . $key . '="' . $value . '"';
+			if ( '-1' !== (string) $value ) {
+				$sanitized_key = sanitize_key( $key );
+				if ( '' !== $sanitized_key ) {
+					$options_string .= ' ' . $sanitized_key . '="' . $value . '"';
+				}
 			}
 		}
 

--- a/includes/widgets/class-wpcm-standings-widget.php
+++ b/includes/widgets/class-wpcm-standings-widget.php
@@ -124,8 +124,9 @@ class WPCM_Standings_Widget extends WPCM_Widget {
 			if ( 'linkclub' === $key ) {
 				$key = 'link_club';
 			}
-			if ( -1 !== $value ) {
-				$options_string .= ' ' . $key . '="' . $value . '"';
+			$sanitized_key = sanitize_key( $key );
+			if ( '-1' !== (string) $value && '' !== $sanitized_key ) {
+				$options_string .= ' ' . $sanitized_key . '="' . $value . '"';
 			}
 		}
 

--- a/includes/wpcm-core-functions.php
+++ b/includes/wpcm-core-functions.php
@@ -532,13 +532,22 @@ function get_the_seasons( $post ) {
  */
 function get_current_season() {
 
-	$seasons         = get_terms( array(
+	$seasons = get_terms( array(
 		'taxonomy'     => 'wpcm_season',
 		'meta_key'     => 'tax_position',
 		'meta_compare' => 'NUMERIC',
 		'orderby'      => 'meta_value_num',
 		'hide_empty'   => false,
 	) );
+
+	if ( ! is_array( $seasons ) || empty( $seasons ) ) {
+		return array(
+			'id'   => null,
+			'name' => null,
+			'slug' => null,
+		);
+	}
+
 	$season          = $seasons[0];
 	$current['id']   = $season->term_id;
 	$current['name'] = $season->name;

--- a/includes/wpcm-player-functions.php
+++ b/includes/wpcm-player-functions.php
@@ -158,7 +158,7 @@ function wpcm_get_appearance_names() {
  */
 function wpcm_get_appearance_and_subs_names() {
 
-	$apps        = wpcm_get_appearance_names();
+	$apps        = (array) wpcm_get_appearance_names();
 	$subs        = array(
 		'subs' => __( 'Sub Appearances', 'wp-club-manager' ),
 	);

--- a/includes/wpcm-player-functions.php
+++ b/includes/wpcm-player-functions.php
@@ -182,14 +182,14 @@ function wpcm_get_player_stats_labels( $subs = false ) {
 	}
 
 	$labels = wpcm_get_preset_labels();
-	$output = false;
+	$output = array();
 	foreach ( $labels as $label => $value ) {
 		if ( get_option( 'wpcm_show_stats_' . $label ) === 'yes' ) {
 			$output[ $label ] = $value;
 		}
 	}
 
-	if ( is_array( $output ) ) {
+	if ( ! empty( $output ) ) {
 		$stats_labels = array_merge( $appearance_label, $output );
 	} else {
 		$stats_labels = $appearance_label;
@@ -208,13 +208,13 @@ function wpcm_get_player_all_labels() {
 	$appearance_labels = wpcm_get_appearance_and_subs_labels();
 
 	$labels = wpcm_get_preset_labels();
-	$output = false;
+	$output = array();
 	foreach ( $labels as $label => $value ) {
 		if ( get_option( 'wpcm_show_stats_' . $label ) === 'yes' ) {
 			$output[ $label ] = $value;
 		}
 	}
-	if ( is_array( $output ) ) {
+	if ( ! empty( $output ) ) {
 		$stats_labels = array_merge( wpcm_player_labels(), $appearance_labels, $output );
 	} else {
 		$stats_labels = $appearance_labels;
@@ -237,13 +237,13 @@ function wpcm_get_player_stats_names( $subs = false ) {
 		$appearance_label = wpcm_get_appearance_names();
 	}
 	$labels = wpcm_get_preset_labels( 'players', 'name' );
-	$output = false;
+	$output = array();
 	foreach ( $labels as $label => $value ) {
 		if ( get_option( 'wpcm_show_stats_' . $label ) === 'yes' ) {
 			$output[ $label ] = $value;
 		}
 	}
-	if ( is_array( $output ) ) {
+	if ( ! empty( $output ) ) {
 		$stats_labels = array_merge( $appearance_label, $output );
 	} else {
 		$stats_labels = $appearance_label;

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -802,17 +802,15 @@ function get_player_subs_total( $id = null, $season = null, $team = null ) {
 
 	$size = count( $matches );
 
-	$total_subs = '0';
+	$total_subs = 0;
 
 	if ( $size > 0 ) {
-
-		$total_subs = 0;
 
 		foreach ( $matches as $match ) {
 
 			$player = maybe_unserialize( get_post_meta( $match->ID, 'wpcm_players', true ) );
 
-			if ( is_array( $player ) && array_key_exists( 'subs', $player ) && array_key_exists( $id, $player['subs'] ) ) {
+			if ( is_array( $player ) && array_key_exists( 'subs', $player ) && is_array( $player['subs'] ) && array_key_exists( $id, $player['subs'] ) && ! empty( $player['subs'][ $id ]['checked'] ) ) {
 
 				++$total_subs;
 

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -32,6 +32,7 @@ function wpcm_get_preset_labels( $type = 'players', $format = 'label' ) {
 		$stats = $data[ $sport ]['stats_labels'];
 	}
 
+	$output = array();
 	foreach ( $stats as $key => $value ) {
 
 		$output[ $key ] = $value[ $format ];
@@ -53,8 +54,9 @@ function wpcm_get_section_stats( $section = 'batting' ) {
 	$data  = wpcm_get_sport_presets();
 	$stats = $data[ $sport ]['stats_labels'];
 
+	$output = array();
 	foreach ( $stats as $key => $value ) {
-		if ( $section === $value['section'] ) {
+		if ( isset( $value['section'] ) && $section === $value['section'] ) {
 
 			$output[ $key ] = $value['label'];
 		}

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -26,16 +26,20 @@ function wpcm_get_preset_labels( $type = 'players', $format = 'label' ) {
 	$sport = get_option( 'wpcm_sport' );
 	$data  = wpcm_get_sport_presets();
 
-	if ( 'standings' === $type ) {
-		$stats = $data[ $sport ]['standings_columns'];
-	} elseif ( 'players' === $type ) {
-		$stats = $data[ $sport ]['stats_labels'];
+	$stats = array();
+	if ( $sport && isset( $data[ $sport ] ) ) {
+		if ( 'standings' === $type && isset( $data[ $sport ]['standings_columns'] ) ) {
+			$stats = $data[ $sport ]['standings_columns'];
+		} elseif ( 'players' === $type && isset( $data[ $sport ]['stats_labels'] ) ) {
+			$stats = $data[ $sport ]['stats_labels'];
+		}
 	}
 
 	$output = array();
 	foreach ( $stats as $key => $value ) {
-
-		$output[ $key ] = $value[ $format ];
+		if ( isset( $value[ $format ] ) ) {
+			$output[ $key ] = $value[ $format ];
+		}
 	}
 
 	return $output;

--- a/includes/wpcm-user-functions.php
+++ b/includes/wpcm-user-functions.php
@@ -101,6 +101,57 @@ function wpcm_create_new_user( $email, $username = '', $password = '' ) {
 }
 
 /**
+ * Get all player IDs linked to a WordPress user.
+ *
+ * Supports multiple players per user account (e.g. a parent
+ * managing children's profiles).
+ *
+ * @param int $user_id WordPress user ID.
+ * @return int[] Array of wpcm_player post IDs.
+ */
+function wpcm_get_linked_players( $user_id ) {
+	if ( empty( $user_id ) ) {
+		return array();
+	}
+
+	$values = get_user_meta( $user_id, '_linked_player', false );
+	return array_map( 'intval', array_filter( $values ) );
+}
+
+/**
+ * Link a player to a WordPress user account.
+ *
+ * Creates the bidirectional relationship between a wpcm_player post
+ * and a WP user.  Handles cleanup when the linked user changes and
+ * prevents duplicate entries so one user can manage many players.
+ *
+ * @param int $player_id The wpcm_player post ID.
+ * @param int $user_id   The WordPress user ID (0 to unlink).
+ */
+function wpcm_link_player_to_user( $player_id, $user_id ) {
+	$old_user_id = (int) get_post_meta( $player_id, '_wpcm_link_users', true );
+	$user_id     = (int) $user_id;
+
+	// Remove old user → player link when the user changes.
+	if ( $old_user_id && $old_user_id !== $user_id ) {
+		delete_user_meta( $old_user_id, '_linked_player', $player_id );
+	}
+
+	if ( $user_id > 0 ) {
+		update_post_meta( $player_id, '_wpcm_link_users', $user_id );
+
+		// Add user → player link only if it does not already exist.
+		$existing = wpcm_get_linked_players( $user_id );
+		if ( ! in_array( $player_id, $existing, true ) ) {
+			add_user_meta( $user_id, '_linked_player', $player_id );
+		}
+	} else {
+		// Unlinking — clear both sides.
+		delete_post_meta( $player_id, '_wpcm_link_users' );
+	}
+}
+
+/**
  * Modify the list of editable roles to prevent non-admin adding admin users.
  *
  * @param  array $roles

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wp-club-manager",
   "title": "WP Club Manager",
   "description": "Plugin",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "homepage": "https://wpclubmanager.com",
   "author": {
     "name": "WP Club Manager",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1771,11 +1771,6 @@ parameters:
 			path: includes/wpcm-stats-functions.php
 
 		-
-			message: "#^Variable \\$stats might not be defined\\.$#"
-			count: 1
-			path: includes/wpcm-stats-functions.php
-
-		-
 			message: "#^Variable \\$team might not be defined\\.$#"
 			count: 1
 			path: includes/wpcm-stats-functions.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1886,11 +1886,6 @@ parameters:
 			path: includes/wpcm-stats-functions.php
 
 		-
-			message: "#^Variable \\$output might not be defined\\.$#"
-			count: 2
-			path: includes/wpcm-stats-functions.php
-
-		-
 			message: "#^Variable \\$season might not be defined\\.$#"
 			count: 1
 			path: includes/wpcm-stats-functions.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,11 +31,6 @@ parameters:
 			path: includes/WPCM_Plugin_Updater.php
 
 		-
-			message: "#^Constant WPCM_VERSION not found\\.$#"
-			count: 13
-			path: includes/admin/class-wpcm-admin-assets.php
-
-		-
 			message: "#^Undefined variable\\: \\$wp_scripts$#"
 			count: 1
 			path: includes/admin/class-wpcm-admin-assets.php
@@ -116,16 +111,6 @@ parameters:
 			path: includes/admin/class-wpcm-admin-meta-boxes.php
 
 		-
-			message: "#^Constant WPCM_PLUGIN_FILE not found\\.$#"
-			count: 5
-			path: includes/admin/class-wpcm-admin-notices.php
-
-		-
-			message: "#^Constant WPCM_VERSION not found\\.$#"
-			count: 5
-			path: includes/admin/class-wpcm-admin-notices.php
-
-		-
 			message: "#^Property WPCM_Admin_Notices\\:\\:\\$notices is never read, only written\\.$#"
 			count: 1
 			path: includes/admin/class-wpcm-admin-notices.php
@@ -148,11 +133,6 @@ parameters:
 		-
 			message: "#^Callback expects 2 parameters, \\$accepted_args is set to 100\\.$#"
 			count: 1
-			path: includes/admin/class-wpcm-admin-post-types.php
-
-		-
-			message: "#^Constant WPCM_URL not found\\.$#"
-			count: 2
 			path: includes/admin/class-wpcm-admin-post-types.php
 
 		-
@@ -223,11 +203,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$term_id of function update_term_meta expects int, array\\<string, int\\|string\\>\\|WP_Error given\\.$#"
 			count: 3
-			path: includes/admin/class-wpcm-admin-setup-wizard.php
-
-		-
-			message: "#^Constant WPCM_VERSION not found\\.$#"
-			count: 2
 			path: includes/admin/class-wpcm-admin-setup-wizard.php
 
 		-
@@ -321,11 +296,6 @@ parameters:
 			path: includes/admin/class-wpcm-admin.php
 
 		-
-			message: "#^Constant WPCM_PLUGIN_FILE not found\\.$#"
-			count: 1
-			path: includes/admin/importers/class-wpcm-club-importer.php
-
-		-
 			message: "#^Call to an undefined method WPCM_Importer\\:\\:greet\\(\\)\\.$#"
 			count: 1
 			path: includes/admin/importers/class-wpcm-importer.php
@@ -346,29 +316,14 @@ parameters:
 			path: includes/admin/importers/class-wpcm-importer.php
 
 		-
-			message: "#^Constant WPCM_PLUGIN_FILE not found\\.$#"
-			count: 1
-			path: includes/admin/importers/class-wpcm-match-importer.php
-
-		-
 			message: "#^Variable \\$labels might not be defined\\.$#"
 			count: 1
 			path: includes/admin/importers/class-wpcm-match-importer.php
 
 		-
-			message: "#^Constant WPCM_PLUGIN_FILE not found\\.$#"
-			count: 1
-			path: includes/admin/importers/class-wpcm-player-importer.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: includes/admin/importers/class-wpcm-player-importer.php
-
-		-
-			message: "#^Constant WPCM_PLUGIN_FILE not found\\.$#"
-			count: 1
-			path: includes/admin/importers/class-wpcm-staff-importer.php
 
 		-
 			message: "#^Parameter \\#1 \\$post of function get_club_details expects array, WP_Post given\\.$#"
@@ -836,16 +791,6 @@ parameters:
 			path: includes/admin/views/html-bulk-edit-match.php
 
 		-
-			message: "#^Constant WPCM_VERSION not found\\.$#"
-			count: 1
-			path: includes/admin/views/html-notice-install.php
-
-		-
-			message: "#^Constant WPCM_VERSION not found\\.$#"
-			count: 1
-			path: includes/admin/views/html-notice-version-update.php
-
-		-
 			message: "#^Variable \\$comps might not be defined\\.$#"
 			count: 1
 			path: includes/admin/views/html-quick-edit-match.php
@@ -886,16 +831,6 @@ parameters:
 			path: includes/class-wp-club-manager.php
 
 		-
-			message: "#^Constant WPCM_PATH not found\\.$#"
-			count: 22
-			path: includes/class-wp-club-manager.php
-
-		-
-			message: "#^Constant WPCM_PLUGIN_FILE not found\\.$#"
-			count: 1
-			path: includes/class-wp-club-manager.php
-
-		-
 			message: "#^Method WP_Club_Manager\\:\\:is_request\\(\\) should return bool but return statement is missing\\.$#"
 			count: 1
 			path: includes/class-wp-club-manager.php
@@ -919,11 +854,6 @@ parameters:
 			message: "#^Variable \\$stats might not be defined\\.$#"
 			count: 1
 			path: includes/class-wpcm-ajax.php
-
-		-
-			message: "#^Constant WPCM_PLUGIN_FILE not found\\.$#"
-			count: 1
-			path: includes/class-wpcm-autoloader.php
 
 		-
 			message: "#^Parameter \\#1 \\$callback of function spl_autoload_register expects \\(callable\\(string\\)\\: void\\)\\|null, '__autoload' given\\.$#"
@@ -951,11 +881,6 @@ parameters:
 			path: includes/class-wpcm-cli.php
 
 		-
-			message: "#^Constant WPCM_VERSION not found\\.$#"
-			count: 3
-			path: includes/class-wpcm-frontend-scripts.php
-
-		-
 			message: "#^Method WPCM_Geocoder\\:\\:osm_geocode\\(\\) has invalid return type varies\\.$#"
 			count: 1
 			path: includes/class-wpcm-geocoder.php
@@ -978,16 +903,6 @@ parameters:
 		-
 			message: "#^Constant W3TC_FILE not found\\.$#"
 			count: 1
-			path: includes/class-wpcm-install.php
-
-		-
-			message: "#^Constant WPCM_PLUGIN_FILE not found\\.$#"
-			count: 1
-			path: includes/class-wpcm-install.php
-
-		-
-			message: "#^Constant WPCM_VERSION not found\\.$#"
-			count: 4
 			path: includes/class-wpcm-install.php
 
 		-
@@ -1031,11 +946,6 @@ parameters:
 			path: includes/class-wpcm-shortcodes.php
 
 		-
-			message: "#^Constant WPCM_VERSION not found\\.$#"
-			count: 1
-			path: includes/class-wpcm-taxonomy-order.php
-
-		-
 			message: "#^Offset 'order' does not exist on string\\|false\\.$#"
 			count: 1
 			path: includes/class-wpcm-taxonomy-order.php
@@ -1044,11 +954,6 @@ parameters:
 			message: "#^Offset 'term_id' does not exist on string\\|false\\.$#"
 			count: 2
 			path: includes/class-wpcm-taxonomy-order.php
-
-		-
-			message: "#^Constant WPCM_TEMPLATE_PATH not found\\.$#"
-			count: 5
-			path: includes/class-wpcm-template-loader.php
 
 		-
 			message: "#^@param tag must not be named \\$this\\. Choose a descriptive alias, for example \\$instance\\.$#"
@@ -1486,11 +1391,6 @@ parameters:
 			path: includes/shortcodes/class-wpcm-shortcode-player-gallery.php
 
 		-
-			message: "#^Constant WPCM_URL not found\\.$#"
-			count: 2
-			path: includes/shortcodes/class-wpcm-shortcode-player-list.php
-
-		-
 			message: "#^Parameter \\#1 \\$post of function get_wpcm_player_stats expects WP_Post\\|null, int given\\.$#"
 			count: 1
 			path: includes/shortcodes/class-wpcm-shortcode-player-list.php
@@ -1521,11 +1421,6 @@ parameters:
 			path: includes/shortcodes/class-wpcm-shortcode-staff-list.php
 
 		-
-			message: "#^Constant WPCM_URL not found\\.$#"
-			count: 1
-			path: includes/shortcodes/class-wpcm-shortcode-staff-list.php
-
-		-
 			message: "#^Parameter \\#1 \\$args of function get_posts expects array\\{numberposts\\?\\: int, category\\?\\: int\\|string, include\\?\\: array\\<int\\>, exclude\\?\\: array\\<int\\>, suppress_filters\\?\\: bool, attachment_id\\?\\: int, author\\?\\: int\\|string, author_name\\?\\: string, \\.\\.\\.\\}\\|null, array\\{post_type\\: 'wpcm_staff', tax_query\\: array\\{\\}\\|array\\{array\\{taxonomy\\: 'wpcm_jobs', terms\\: mixed, field\\: 'term_id'\\}\\}, posts_per_page\\: mixed, order\\: string, orderby\\: string, suppress_filters\\: 0, post__in\\: array\\} given\\.$#"
 			count: 1
 			path: includes/shortcodes/class-wpcm-shortcode-staff-list.php
@@ -1544,11 +1439,6 @@ parameters:
 			message: "#^Variable \\$venue in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 2
 			path: includes/shortcodes/legacy/class-wpcm-shortcode-matches.php
-
-		-
-			message: "#^Constant WPCM_URL not found\\.$#"
-			count: 2
-			path: includes/shortcodes/legacy/class-wpcm-shortcode-players.php
 
 		-
 			message: "#^Parameter \\#1 \\$args of function get_posts expects array\\{numberposts\\?\\: int, category\\?\\: int\\|string, include\\?\\: array\\<int\\>, exclude\\?\\: array\\<int\\>, suppress_filters\\?\\: bool, attachment_id\\?\\: int, author\\?\\: int\\|string, author_name\\?\\: string, \\.\\.\\.\\}\\|null, array\\{post_type\\: 'wpcm_player', tax_query\\: array\\{\\}\\|array\\{0\\: array\\{taxonomy\\: 'wpcm_season', terms\\: mixed, field\\: 'term_id'\\}, 1\\?\\: array\\{taxonomy\\: 'wpcm_position'\\|'wpcm_team', terms\\: mixed, field\\: 'term_id'\\}, 2\\?\\: array\\{taxonomy\\: 'wpcm_position', terms\\: mixed, field\\: 'term_id'\\}\\}\\|array\\{0\\: array\\{taxonomy\\: 'wpcm_team', terms\\: mixed, field\\: 'term_id'\\}, 1\\?\\: array\\{taxonomy\\: 'wpcm_position', terms\\: mixed, field\\: 'term_id'\\}\\}\\|array\\{array\\{taxonomy\\: 'wpcm_position', terms\\: mixed, field\\: 'term_id'\\}\\}, numposts\\: mixed, posts_per_page\\: mixed, orderby\\: 'menu_order'\\|'meta_value_num'\\|'name', meta_key\\: 'wpcm_number', order\\: string, suppress_filters\\: 0\\} given\\.$#"
@@ -1574,11 +1464,6 @@ parameters:
 			message: "#^Variable \\$transient_name might not be defined\\.$#"
 			count: 2
 			path: includes/shortcodes/legacy/class-wpcm-shortcode-players.php
-
-		-
-			message: "#^Constant WPCM_URL not found\\.$#"
-			count: 1
-			path: includes/shortcodes/legacy/class-wpcm-shortcode-staff.php
 
 		-
 			message: "#^Variable \\$staff_details might not be defined\\.$#"
@@ -1696,16 +1581,6 @@ parameters:
 			path: includes/wpcm-core-functions.php
 
 		-
-			message: "#^Constant WPCM_TEMPLATE_DEBUG_MODE not found\\.$#"
-			count: 1
-			path: includes/wpcm-core-functions.php
-
-		-
-			message: "#^Constant WPCM_TEMPLATE_PATH not found\\.$#"
-			count: 1
-			path: includes/wpcm-core-functions.php
-
-		-
 			message: "#^Offset 0 on \\*NEVER\\* in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: includes/wpcm-core-functions.php
@@ -1727,6 +1602,11 @@ parameters:
 
 		-
 			message: "#^Property WP_Post\\:\\:\\$post_type \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/wpcm-core-functions.php
+
+		-
+			message: "#^Right side of \\|\\| is always false\\.$#"
 			count: 1
 			path: includes/wpcm-core-functions.php
 
@@ -1901,11 +1781,6 @@ parameters:
 			path: includes/wpcm-stats-functions.php
 
 		-
-			message: "#^Constant WPCM_VERSION not found\\.$#"
-			count: 1
-			path: includes/wpcm-template-functions.php
-
-		-
 			message: "#^Parameter \\#4 \\$atts of function wpcm_form_dropdown expects string\\|null, array\\<string, string\\> given\\.$#"
 			count: 2
 			path: includes/wpcm-template-functions.php
@@ -1929,11 +1804,6 @@ parameters:
 			message: "#^Variable \\$post might not be defined\\.$#"
 			count: 5
 			path: templates/content-single-club.php
-
-		-
-			message: "#^Constant WPCM_URL not found\\.$#"
-			count: 1
-			path: templates/content-single-staff.php
 
 		-
 			message: "#^Variable \\$post might not be defined\\.$#"
@@ -2514,11 +2384,6 @@ parameters:
 			message: "#^Offset 'name' does not exist on non\\-falsy\\-string\\.$#"
 			count: 1
 			path: templates/single-match/venue.php
-
-		-
-			message: "#^Constant WPCM_URL not found\\.$#"
-			count: 1
-			path: templates/single-player/meta.php
 
 		-
 			message: "#^Variable \\$season might not be defined\\.$#"

--- a/phpstan-stubs/wpcm-constants.php
+++ b/phpstan-stubs/wpcm-constants.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Stubs for WPCM constants defined at runtime in wpclubmanager.php.
+ * PHPStan can't see these because they're set in the plugin constructor.
+ *
+ * @phpstan-type WPCMConstants array{
+ *   WPCM_PLUGIN_FILE: string,
+ *   WPCM_VERSION: string,
+ *   WPCM_URL: string,
+ *   WPCM_PATH: string,
+ *   WPCM_TEMPLATE_PATH: string,
+ *   WPCM_PLUGIN_BASENAME: string,
+ *   WPCM_TEMPLATE_DEBUG_MODE: bool
+ * }
+ */
+
+// phpcs:disable
+define( 'WPCM_PLUGIN_FILE', '' );
+define( 'WPCM_VERSION', '' );
+define( 'WPCM_URL', '' );
+define( 'WPCM_PATH', '' );
+define( 'WPCM_TEMPLATE_PATH', 'wp-club-manager/' );
+define( 'WPCM_PLUGIN_BASENAME', '' );
+define( 'WPCM_TEMPLATE_DEBUG_MODE', false );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ parameters:
     level: 5
     bootstrapFiles:
         - phpstan-stubs/wp-cli.php
+        - phpstan-stubs/wpcm-constants.php
     paths:
         - .
     excludePaths:

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Requires at least: 4.9
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable Tag: 2.3.1
+Stable Tag: 2.3.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -170,6 +170,16 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 11. Front-end League Table
 
 == Changelog ==
+
+= 2.3.2 - 8th April 2026 =
+
+* Fix: Sub appearances count showing incorrectly (#84)
+* Fix: PHP 8.x fatal error - array_merge null argument in settings (#109)
+* Fix: Players List and Standings widgets render empty (#103)
+* Fix: PHP 8.x fatal errors from null property access (#93)
+* Fix: Allow multiple players per user account (#101)
+* Fix: Anchor vendor pattern in .distignore to preserve JS assets (#105)
+* Add: WPCM constants stub for PHPStan (#107)
 
 = 2.3.1 - 6th April 2026 =
 

--- a/templates/single-player/stats-table.php
+++ b/templates/single-player/stats-table.php
@@ -51,14 +51,14 @@ $custom_stats = get_post_meta( $post->ID, '_wpcm_custom_player_stats', true ); ?
 						if ( get_option( 'wpcm_show_stats_subs' ) === 'yes' ) {
 							$subs = get_player_subs_total( $post->ID, $season, $team );
 							if ( $subs > 0 ) {
-								$sub = ' <span class="sub-appearances">(' . $subs . ')</span>';
+								$sub = ' <span class="sub-appearances">(' . absint( $subs ) . ')</span>';
 							} else {
 								$sub = '';
 							}
 						}
 						?>
 
-						<td><span data-index="appearances"><?php wpcm_stats_value( $stats, 'total', 'appearances' ); ?><?php echo esc_html( 'yes' === get_option( 'wpcm_show_stats_subs' ) ? $sub : '' ); ?></span></td>
+						<td><span data-index="appearances"><?php wpcm_stats_value( $stats, 'total', 'appearances' ); ?><?php echo wp_kses( 'yes' === get_option( 'wpcm_show_stats_subs' ) ? $sub : '', array( 'span' => array( 'class' => array() ) ) ); ?></span></td>
 
 						<?php
 					}

--- a/tests/wpunit/DistIgnoreTest.php
+++ b/tests/wpunit/DistIgnoreTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for .distignore to prevent accidental exclusion of shipped assets.
+ */
+
+class DistIgnoreTest extends WPCMTestCase {
+
+	/**
+	 * The parsed lines from .distignore (comments and blanks stripped).
+	 *
+	 * @var string[]
+	 */
+	private $patterns;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		$distignore_path = dirname( __DIR__, 2 ) . '/.distignore';
+		$this->assertFileExists( $distignore_path, '.distignore must exist' );
+
+		$lines = file( $distignore_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
+		$this->patterns = array_filter(
+			$lines,
+			function ( $line ) {
+				return '' !== trim( $line ) && '#' !== $line[0];
+			}
+		);
+	}
+
+	/**
+	 * Vendor JS assets must not be excluded by .distignore.
+	 *
+	 * The "vendor" pattern in .distignore is intended to exclude the
+	 * top-level Composer vendor/ directory. If it is not anchored with
+	 * a leading slash, rsync will also exclude assets/js/vendor/ which
+	 * ships required libraries (Chosen, Timepicker, etc.).
+	 *
+	 * @see https://github.com/WPClubManager/wp-club-manager/issues/104
+	 */
+	public function test_vendor_pattern_is_anchored_to_root() {
+		foreach ( $this->patterns as $pattern ) {
+			$trimmed = trim( $pattern );
+
+			// Skip anything that isn't about the word "vendor".
+			if ( false === strpos( $trimmed, 'vendor' ) ) {
+				continue;
+			}
+
+			// An unanchored "vendor" (no leading slash) would match
+			// assets/js/vendor/ and break the build.
+			$this->assertStringStartsWith(
+				'/',
+				$trimmed,
+				sprintf(
+					'.distignore pattern "%s" is not anchored — it will exclude assets/js/vendor/. Use "/%s" instead.',
+					$trimmed,
+					ltrim( $trimmed, '/' )
+				)
+			);
+		}
+	}
+
+	/**
+	 * All four vendor JS files referenced by the admin scripts must exist.
+	 */
+	public function test_required_vendor_js_files_exist() {
+		$plugin_dir = dirname( __DIR__, 2 );
+
+		$required_files = array(
+			'assets/js/vendor/jquery-chosen/chosen.jquery.min.js',
+			'assets/js/vendor/jquery-chosen/chosen.order.jquery.min.js',
+			'assets/js/vendor/jquery-chosen/ajax-chosen.jquery.min.js',
+			'assets/js/vendor/jquery.timepicker.min.js',
+		);
+
+		foreach ( $required_files as $file ) {
+			$this->assertFileExists(
+				$plugin_dir . '/' . $file,
+				sprintf( 'Required vendor JS file missing: %s', $file )
+			);
+		}
+	}
+}

--- a/tests/wpunit/DistIgnoreTest.php
+++ b/tests/wpunit/DistIgnoreTest.php
@@ -19,6 +19,7 @@ class DistIgnoreTest extends WPCMTestCase {
 		$this->assertFileExists( $distignore_path, '.distignore must exist' );
 
 		$lines = file( $distignore_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
+		$this->assertIsArray( $lines, '.distignore could not be read' );
 		$this->patterns = array_filter(
 			$lines,
 			function ( $line ) {
@@ -38,6 +39,8 @@ class DistIgnoreTest extends WPCMTestCase {
 	 * @see https://github.com/WPClubManager/wp-club-manager/issues/104
 	 */
 	public function test_vendor_pattern_is_anchored_to_root() {
+		$found = false;
+
 		foreach ( $this->patterns as $pattern ) {
 			$trimmed = trim( $pattern );
 
@@ -45,6 +48,8 @@ class DistIgnoreTest extends WPCMTestCase {
 			if ( false === strpos( $trimmed, 'vendor' ) ) {
 				continue;
 			}
+
+			$found = true;
 
 			// An unanchored "vendor" (no leading slash) would match
 			// assets/js/vendor/ and break the build.
@@ -58,6 +63,8 @@ class DistIgnoreTest extends WPCMTestCase {
 				)
 			);
 		}
+
+		$this->assertTrue( $found, '.distignore must contain at least one vendor exclusion pattern.' );
 	}
 
 	/**

--- a/tests/wpunit/Php8CompatTest.php
+++ b/tests/wpunit/Php8CompatTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Tests for PHP 8.x compatibility fixes (#91).
+ *
+ * Covers null property access, uninitialized array variables,
+ * and false-to-array implicit conversion.
+ */
+
+class Php8CompatTest extends WPCMTestCase {
+
+	public function _setUp() {
+		parent::_setUp();
+		update_option( 'wpcm_sport', 'soccer' );
+	}
+
+	public function _tearDown() {
+		parent::_tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// get_current_season() — must not fatal when no seasons exist
+	// -----------------------------------------------------------------------
+
+	public function test_get_current_season_returns_empty_when_no_seasons() {
+		// Stub get_terms() for wpcm_season to return an empty array,
+		// avoiding state leakage from deleting real terms.
+		$filter = function ( $terms, $query ) {
+			if ( isset( $query->query_vars['taxonomy'] )
+				&& in_array( 'wpcm_season', (array) $query->query_vars['taxonomy'], true )
+			) {
+				return array();
+			}
+
+			return $terms;
+		};
+		add_filter( 'terms_pre_query', $filter, 10, 2 );
+
+		$result = get_current_season();
+
+		remove_filter( 'terms_pre_query', $filter, 10 );
+
+		$this->assertIsArray( $result );
+		$this->assertNull( $result['id'] );
+		$this->assertNull( $result['name'] );
+		$this->assertNull( $result['slug'] );
+	}
+
+	public function test_get_current_season_returns_data_when_season_exists() {
+		$season_name = 'Season 2024 ' . uniqid();
+		$term        = wp_insert_term(
+			$season_name,
+			'wpcm_season',
+			array(
+				'slug' => sanitize_title( $season_name ),
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $term ), is_wp_error( $term ) ? $term->get_error_message() : '' );
+		$this->assertIsArray( $term );
+
+		$term_id = $term['term_id'];
+
+		update_term_meta( $term_id, 'tax_position', 1 );
+
+		// Stub get_terms() so only our created term is returned,
+		// making the assertion deterministic regardless of other suite terms.
+		$term_obj = get_term( $term_id, 'wpcm_season' );
+		$filter   = function ( $terms, $query ) use ( $term_obj ) {
+			if ( isset( $query->query_vars['taxonomy'] )
+				&& in_array( 'wpcm_season', (array) $query->query_vars['taxonomy'], true )
+			) {
+				return array( $term_obj );
+			}
+
+			return $terms;
+		};
+		add_filter( 'terms_pre_query', $filter, 10, 2 );
+
+		$result = get_current_season();
+
+		remove_filter( 'terms_pre_query', $filter, 10 );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( $term_id, $result['id'] );
+		$this->assertEquals( $season_name, $result['name'] );
+		$this->assertNotEmpty( $result['slug'] );
+
+		wp_delete_term( $term_id, 'wpcm_season' );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_preset_labels() — $output must be initialized as array
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_preset_labels_returns_array_not_undefined() {
+		$result = wpcm_get_preset_labels( 'players', 'label' );
+		$this->assertIsArray( $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_section_stats() — $output must be initialized as array
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_section_stats_returns_array() {
+		// Use a section that likely has no stats to verify $output is initialized.
+		$result = wpcm_get_section_stats( 'nonexistent_section' );
+		$this->assertIsArray( $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_player_stats_labels() — $output = false then $output[$label]
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_player_stats_labels_no_fatal_when_no_stats_enabled() {
+		// Disable all stats to force $output to remain false / empty.
+		$labels = wpcm_get_preset_labels();
+		foreach ( $labels as $label => $value ) {
+			delete_option( 'wpcm_show_stats_' . $label );
+		}
+
+		$result = wpcm_get_player_stats_labels();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'appearances', $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_player_all_labels() — same $output = false pattern
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_player_all_labels_no_fatal_when_no_stats_enabled() {
+		$labels = wpcm_get_preset_labels();
+		foreach ( $labels as $label => $value ) {
+			delete_option( 'wpcm_show_stats_' . $label );
+		}
+
+		$result = wpcm_get_player_all_labels();
+		$this->assertIsArray( $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_player_stats_names() — same $output = false pattern
+	// -----------------------------------------------------------------------
+
+	public function test_wpcm_get_player_stats_names_no_fatal_when_no_stats_enabled() {
+		$labels = wpcm_get_preset_labels( 'players', 'name' );
+		foreach ( $labels as $label => $value ) {
+			delete_option( 'wpcm_show_stats_' . $label );
+		}
+
+		$result = wpcm_get_player_stats_names();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'appearances', $result );
+	}
+}

--- a/tests/wpunit/Php8CompatTest.php
+++ b/tests/wpunit/Php8CompatTest.php
@@ -97,6 +97,32 @@ class Php8CompatTest extends WPCMTestCase {
 		$this->assertIsArray( $result );
 	}
 
+	public function test_wpcm_get_preset_labels_returns_empty_array_when_sport_missing() {
+		delete_option( 'wpcm_sport' );
+
+		$result = wpcm_get_preset_labels( 'players', 'label' );
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+
+		// Restore for subsequent tests.
+		update_option( 'wpcm_sport', 'soccer' );
+	}
+
+	public function test_wpcm_get_preset_labels_returns_empty_array_when_sport_unknown() {
+		update_option( 'wpcm_sport', 'nonexistent_sport' );
+
+		$result = wpcm_get_preset_labels( 'players', 'label' );
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+
+		$standings = wpcm_get_preset_labels( 'standings', 'label' );
+		$this->assertIsArray( $standings );
+		$this->assertEmpty( $standings );
+
+		// Restore for subsequent tests.
+		update_option( 'wpcm_sport', 'soccer' );
+	}
+
 	// -----------------------------------------------------------------------
 	// wpcm_get_section_stats() — $output must be initialized as array
 	// -----------------------------------------------------------------------

--- a/tests/wpunit/PlayerUserLinkTest.php
+++ b/tests/wpunit/PlayerUserLinkTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Tests for linking players to WordPress user accounts.
+ *
+ * Covers issue #100: allow multiple players per user account.
+ */
+
+class PlayerUserLinkTest extends WPCMTestCase {
+
+	/** @var int */
+	private $user_id;
+
+	/** @var int */
+	private $player_one;
+
+	/** @var int */
+	private $player_two;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		$this->user_id = $this->factory()->user->create( array(
+			'role' => 'player',
+		) );
+
+		$this->player_one = wp_insert_post( array(
+			'post_type'   => 'wpcm_player',
+			'post_title'  => 'Alice Smith',
+			'post_status' => 'publish',
+		) );
+
+		$this->player_two = wp_insert_post( array(
+			'post_type'   => 'wpcm_player',
+			'post_title'  => 'Bob Smith',
+			'post_status' => 'publish',
+		) );
+	}
+
+	public function _tearDown() {
+		wp_delete_post( $this->player_one, true );
+		wp_delete_post( $this->player_two, true );
+		wp_delete_user( $this->user_id );
+		parent::_tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_linked_players()
+	// -----------------------------------------------------------------------
+
+	public function test_get_linked_players_returns_empty_array_for_unlinked_user() {
+		$this->assertSame( array(), wpcm_get_linked_players( $this->user_id ) );
+	}
+
+	public function test_get_linked_players_returns_single_player() {
+		add_user_meta( $this->user_id, '_linked_player', $this->player_one );
+
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertSame( array( $this->player_one ), $linked );
+	}
+
+	public function test_get_linked_players_returns_multiple_players() {
+		add_user_meta( $this->user_id, '_linked_player', $this->player_one );
+		add_user_meta( $this->user_id, '_linked_player', $this->player_two );
+
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertCount( 2, $linked );
+		$this->assertContains( $this->player_one, $linked );
+		$this->assertContains( $this->player_two, $linked );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_link_player_to_user()
+	// -----------------------------------------------------------------------
+
+	public function test_link_player_to_user_creates_bidirectional_link() {
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+
+		$this->assertEquals( $this->user_id, get_post_meta( $this->player_one, '_wpcm_link_users', true ) );
+		$this->assertContains( $this->player_one, wpcm_get_linked_players( $this->user_id ) );
+	}
+
+	public function test_link_multiple_players_to_same_user() {
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+		wpcm_link_player_to_user( $this->player_two, $this->user_id );
+
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertCount( 2, $linked );
+		$this->assertContains( $this->player_one, $linked );
+		$this->assertContains( $this->player_two, $linked );
+	}
+
+	public function test_link_does_not_create_duplicate_entries() {
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertCount( 1, $linked );
+	}
+
+	public function test_changing_user_removes_old_user_link() {
+		$other_user = $this->factory()->user->create( array(
+			'role' => 'player',
+		) );
+
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+		wpcm_link_player_to_user( $this->player_one, $other_user );
+
+		// Old user should no longer have this player linked.
+		$this->assertNotContains( $this->player_one, wpcm_get_linked_players( $this->user_id ) );
+		// New user should have it.
+		$this->assertContains( $this->player_one, wpcm_get_linked_players( $other_user ) );
+
+		wp_delete_user( $other_user );
+	}
+
+	public function test_unlinking_user_removes_bidirectional_link() {
+		wpcm_link_player_to_user( $this->player_one, $this->user_id );
+		wpcm_link_player_to_user( $this->player_two, $this->user_id );
+
+		// Unlink player one by setting user to 0 / none.
+		wpcm_link_player_to_user( $this->player_one, 0 );
+
+		$this->assertEquals( '', get_post_meta( $this->player_one, '_wpcm_link_users', true ) );
+		$linked = wpcm_get_linked_players( $this->user_id );
+		$this->assertCount( 1, $linked );
+		$this->assertContains( $this->player_two, $linked );
+	}
+}

--- a/tests/wpunit/SubAppearancesTest.php
+++ b/tests/wpunit/SubAppearancesTest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Tests for sub appearances count on the player profile.
+ *
+ * Verifies that get_player_subs_total() correctly counts only
+ * checked substitute appearances, and that unchecked legacy subs
+ * are excluded.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/83
+ */
+
+class SubAppearancesTest extends WPCMTestCase {
+
+	/** @var int */
+	private $club_id;
+
+	/** @var int */
+	private $away_club_id;
+
+	/** @var int */
+	private $player_id;
+
+	/** @var int[] Match IDs created during tests. */
+	private $match_ids = array();
+
+	public function _setUp() {
+		parent::_setUp();
+
+		update_option( 'wpcm_sport', 'soccer' );
+
+		$this->club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Subs Test FC',
+			'post_status' => 'publish',
+		) );
+
+		$this->away_club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Subs Away United',
+			'post_status' => 'publish',
+		) );
+
+		update_option( 'wpcm_default_club', $this->club_id );
+
+		$this->player_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_player',
+			'post_title'  => 'Subs Test Player',
+			'post_status' => 'publish',
+		) );
+	}
+
+	public function _tearDown() {
+		foreach ( $this->match_ids as $match_id ) {
+			wp_delete_post( $match_id, true );
+		}
+		$this->match_ids = array();
+
+		wp_delete_post( $this->player_id, true );
+		wp_delete_post( $this->club_id, true );
+		wp_delete_post( $this->away_club_id, true );
+		delete_option( 'wpcm_default_club' );
+
+		parent::_tearDown();
+	}
+
+	/**
+	 * Helper to create a match with player data.
+	 *
+	 * @param array $players Array wpcm_players structure (serialised internally).
+	 * @return int Match post ID.
+	 */
+	private function create_match( $players ) {
+		$match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Subs Test Match',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $match_id, 'wpcm_home_club', $this->club_id );
+		update_post_meta( $match_id, 'wpcm_away_club', $this->away_club_id );
+		update_post_meta( $match_id, 'wpcm_played', '1' );
+		update_post_meta( $match_id, 'wpcm_players', serialize( $players ) );
+
+		$this->match_ids[] = $match_id;
+
+		return $match_id;
+	}
+
+	// -------------------------------------------------------------------
+	// get_player_subs_total() — core sub count
+	// -------------------------------------------------------------------
+
+	public function test_checked_sub_is_counted() {
+		$this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 0,
+					'assists' => 0,
+				),
+			),
+		) );
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 1, $subs );
+	}
+
+	public function test_unchecked_sub_is_not_counted() {
+		// Legacy data: player in subs array but without 'checked' key.
+		$this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'goals'   => 0,
+					'assists' => 0,
+				),
+			),
+		) );
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 0, $subs, 'Unchecked sub should not be counted' );
+	}
+
+	public function test_multiple_matches_count_only_checked_subs() {
+		// Match 1: player is a checked sub.
+		$this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 1,
+				),
+			),
+		) );
+
+		// Match 2: player is in subs but NOT checked (legacy data).
+		$this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'goals' => 0,
+				),
+			),
+		) );
+
+		// Match 3: player is a checked sub.
+		$this->create_match( array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 0,
+				),
+			),
+		) );
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 2, $subs, 'Only checked subs should be counted' );
+	}
+
+	public function test_lineup_player_not_counted_as_sub() {
+		$this->create_match( array(
+			'lineup' => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 2,
+				),
+			),
+			'subs'   => array(),
+		) );
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 0, $subs );
+	}
+
+	public function test_already_unserialized_meta_is_handled() {
+		$match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Subs Unserialized Meta Match',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $match_id, 'wpcm_home_club', $this->club_id );
+		update_post_meta( $match_id, 'wpcm_away_club', $this->away_club_id );
+		update_post_meta( $match_id, 'wpcm_played', '1' );
+
+		// Store as array (no manual serialize) — maybe_unserialize() should handle this.
+		update_post_meta( $match_id, 'wpcm_players', array(
+			'lineup' => array(),
+			'subs'   => array(
+				$this->player_id => array(
+					'checked' => '1',
+					'goals'   => 0,
+				),
+			),
+		) );
+
+		$this->match_ids[] = $match_id;
+
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 1, $subs, 'Already-unserialized meta should be handled by maybe_unserialize' );
+	}
+
+	public function test_subs_total_returns_zero_with_no_matches() {
+		$subs = get_player_subs_total( $this->player_id );
+
+		$this->assertEquals( 0, $subs );
+	}
+}

--- a/tests/wpunit/WidgetRenderTest.php
+++ b/tests/wpunit/WidgetRenderTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Tests for widget render methods -- specifically that string "-1"
+ * values (produced by sanitize_text_field) are correctly excluded
+ * from shortcode attribute output.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/102
+ */
+
+class WidgetRenderTest extends WPCMTestCase {
+
+	/**
+	 * Default widget wrapper args.
+	 *
+	 * @var array
+	 */
+	private $widget_args = array(
+		'before_widget' => '<div>',
+		'after_widget'  => '</div>',
+		'before_title'  => '<h2>',
+		'after_title'   => '</h2>',
+		'widget_id'     => 'test-widget-1',
+	);
+
+	/**
+	 * Captured shortcode attributes from the stub.
+	 *
+	 * @var array|null
+	 */
+	private $captured_atts;
+
+	/**
+	 * Original shortcode callbacks to restore in teardown.
+	 *
+	 * @var array
+	 */
+	private $original_shortcodes = array();
+
+	/**
+	 * Register shortcode stubs before each test.
+	 */
+	public function _setUp() {
+		parent::_setUp();
+
+		global $shortcode_tags;
+
+		$this->captured_atts = null;
+
+		// Save original shortcode callbacks so we can restore them.
+		foreach ( array( 'player_list', 'league_table' ) as $tag ) {
+			if ( isset( $shortcode_tags[ $tag ] ) ) {
+				$this->original_shortcodes[ $tag ] = $shortcode_tags[ $tag ];
+			}
+		}
+
+		$stub = function ( $atts ) {
+			$this->captured_atts = $atts;
+			return '';
+		};
+
+		add_shortcode( 'player_list', $stub );
+		add_shortcode( 'league_table', $stub );
+	}
+
+	/**
+	 * Restore original shortcode callbacks after each test.
+	 */
+	public function _tearDown() {
+		// Restore original shortcodes so other tests are not affected.
+		foreach ( $this->original_shortcodes as $tag => $callback ) {
+			add_shortcode( $tag, $callback );
+		}
+		$this->original_shortcodes = array();
+
+		parent::_tearDown();
+	}
+
+	/**
+	 * Test that WPCM_Players_Widget excludes string "-1" values from shortcode atts.
+	 */
+	public function test_players_widget_excludes_string_minus_one() {
+		$widget   = new WPCM_Players_Widget();
+		$instance = array(
+			'title'           => 'Players',
+			'id'              => '42',
+			'limit'           => '3',
+			'position'        => '-1',
+			'display_options' => '-1',
+			'link_options'    => '-1',
+			'linktext'        => 'View all',
+			'linkpage'        => 'None',
+		);
+
+		ob_start();
+		$widget->widget( $this->widget_args, $instance );
+		ob_get_clean();
+
+		$this->assertIsArray( $this->captured_atts, 'player_list shortcode should be invoked.' );
+		$this->assertArrayNotHasKey( 'position', $this->captured_atts, 'String "-1" position should be excluded.' );
+		$this->assertArrayNotHasKey( 'display_options', $this->captured_atts, 'String "-1" display_options should be excluded.' );
+		$this->assertArrayNotHasKey( 'link_options', $this->captured_atts, 'String "-1" link_options should be excluded.' );
+		$this->assertSame( 'Players', $this->captured_atts['title'] );
+		$this->assertSame( '42', $this->captured_atts['id'] );
+	}
+
+	/**
+	 * Test that WPCM_Standings_Widget excludes string "-1" values from shortcode atts.
+	 */
+	public function test_standings_widget_excludes_string_minus_one() {
+		$widget   = new WPCM_Standings_Widget();
+		$instance = array(
+			'title'        => 'Standings',
+			'id'           => '99',
+			'limit'        => '7',
+			'link_options' => '-1',
+			'linktext'     => 'View all standings',
+			'linkpage'     => 'None',
+		);
+
+		ob_start();
+		$widget->widget( $this->widget_args, $instance );
+		ob_get_clean();
+
+		$this->assertIsArray( $this->captured_atts, 'league_table shortcode should be invoked.' );
+		$this->assertArrayNotHasKey( 'link_options', $this->captured_atts, 'String "-1" link_options should be excluded.' );
+		$this->assertSame( 'Standings', $this->captured_atts['title'] );
+		$this->assertSame( '99', $this->captured_atts['id'] );
+	}
+
+	/**
+	 * Test that integer -1 values are also excluded for WPCM_Players_Widget.
+	 */
+	public function test_players_widget_excludes_integer_minus_one() {
+		$widget   = new WPCM_Players_Widget();
+		$instance = array(
+			'title'           => 'Players',
+			'id'              => '42',
+			'display_options' => -1,
+			'link_options'    => -1,
+		);
+
+		ob_start();
+		$widget->widget( $this->widget_args, $instance );
+		ob_get_clean();
+
+		$this->assertIsArray( $this->captured_atts, 'player_list shortcode should be invoked.' );
+		$this->assertArrayNotHasKey( 'display_options', $this->captured_atts, 'Integer -1 display_options should be excluded.' );
+		$this->assertArrayNotHasKey( 'link_options', $this->captured_atts, 'Integer -1 link_options should be excluded.' );
+	}
+
+	/**
+	 * Test that integer -1 values are also excluded for WPCM_Standings_Widget.
+	 */
+	public function test_standings_widget_excludes_integer_minus_one() {
+		$widget   = new WPCM_Standings_Widget();
+		$instance = array(
+			'title'        => 'Standings',
+			'id'           => '99',
+			'limit'        => '7',
+			'link_options' => -1,
+			'linktext'     => 'View all standings',
+			'linkpage'     => 'None',
+		);
+
+		ob_start();
+		$widget->widget( $this->widget_args, $instance );
+		ob_get_clean();
+
+		$this->assertIsArray( $this->captured_atts, 'league_table shortcode should be invoked.' );
+		$this->assertArrayNotHasKey( 'link_options', $this->captured_atts, 'Integer -1 link_options should be excluded.' );
+		$this->assertSame( 'Standings', $this->captured_atts['title'] );
+		$this->assertSame( '99', $this->captured_atts['id'] );
+	}
+}

--- a/wpclubmanager.php
+++ b/wpclubmanager.php
@@ -6,7 +6,7 @@
  * Author: WP Club Manager
  * Author URI: https://wpclubmanager.com
  * Requires PHP: 7.4
- * Version: 2.3.1
+ * Version: 2.3.2
  * Text Domain: wp-club-manager
  * Domain Path: /languages/
  * License: GPLv3
@@ -27,7 +27,7 @@ if ( ! function_exists( 'WPCM' ) ) :
 	function WPCM() {
 		require_once __DIR__ . '/includes/class-wp-club-manager.php';
 
-		return WP_Club_Manager::instance( __FILE__, '2.3.1' );
+		return WP_Club_Manager::instance( __FILE__, '2.3.2' );
 	}
 endif;
 


### PR DESCRIPTION
## Summary

Patch release with bug fixes from develop:

- Fix: Sub appearances count showing incorrectly (#84)
- Fix: PHP 8.x fatal error - array_merge null argument in settings (#109)
- Fix: Players List and Standings widgets render empty (#103)
- Fix: PHP 8.x fatal errors from null property access (#93)
- Fix: Allow multiple players per user account (#101)
- Fix: Anchor vendor pattern in .distignore to preserve JS assets (#105)
- Add: WPCM constants stub for PHPStan (#107)

## Test plan

- [ ] Verify version shows 2.3.2 in plugin header
- [ ] Smoke test player stats, widgets, and settings pages on PHP 8.x
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)