### PR TITLE
[Fix] League table club logos not showing after 2.3.1 (#111)

### DIFF
--- a/includes/shortcodes/class-wpcm-shortcode-league-table.php
+++ b/includes/shortcodes/class-wpcm-shortcode-league-table.php
@@ -104,7 +104,7 @@ class WPCM_Shortcode_League_Table {
 					$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season, $manual_stats[ $club->ID ] );
 					$club->wpcm_stats        = $total_stats;
 				}
-				if ( 1 === $thumb ) {
+				if ( ! empty( $thumb ) ) {
 					if ( has_post_thumbnail( $club->ID ) ) {
 						$club->thumb = get_the_post_thumbnail( $club->ID, 'crest-small' );
 					} else {

--- a/includes/shortcodes/legacy/class-wpcm-shortcode-standings.php
+++ b/includes/shortcodes/legacy/class-wpcm-shortcode-standings.php
@@ -100,7 +100,7 @@ class WPCM_Shortcode_Standings {
 			foreach ( $clubs as $club ) {
 				$club_stats       = get_wpcm_club_total_stats( $club->ID, $comp, $season );
 				$club->wpcm_stats = $club_stats;
-				if ( 1 === $thumb ) {
+				if ( ! empty( $thumb ) ) {
 					if ( has_post_thumbnail( $club->ID ) ) {
 						$club->thumb = get_the_post_thumbnail( $club->ID, 'crest-small' );
 					} else {

--- a/tests/wpunit/LeagueTableThumbTest.php
+++ b/tests/wpunit/LeagueTableThumbTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Tests that the league table shortcode correctly handles string "1"
+ * for the thumb attribute (as passed by widgets and shortcode parsing).
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/111
+ */
+
+class LeagueTableThumbTest extends WPCMTestCase {
+
+	/**
+	 * Test that the thumb attribute check works with string "1".
+	 *
+	 * The PHPCS cleanup in 2.3.1 changed `1 == $thumb` to `1 === $thumb`,
+	 * but shortcode attributes are always strings. This caused club logos
+	 * to stop rendering. The fix uses `! empty( $thumb )` instead.
+	 */
+	public function test_thumb_attribute_works_with_string_value() {
+		// Simulate how the shortcode class processes the thumb attribute.
+		// When passed via shortcode, $thumb is always a string.
+		$thumb_from_shortcode = '1';
+
+		// Before fix: 1 === '1' would be false (bug).
+		// After fix: ! empty( '1' ) is true (correct).
+		$this->assertTrue( ! empty( $thumb_from_shortcode ), 'String "1" thumb should be truthy.' );
+	}
+
+	/**
+	 * Test that thumb="0" correctly disables thumbnails.
+	 */
+	public function test_thumb_attribute_zero_disables_thumbs() {
+		$thumb_disabled = '0';
+
+		// "0" is empty in PHP, so ! empty( "0" ) is false - correct behaviour.
+		$this->assertFalse( ! empty( $thumb_disabled ), 'String "0" thumb should be falsy.' );
+	}
+
+	/**
+	 * Test that thumb="" (empty string) disables thumbnails.
+	 */
+	public function test_thumb_attribute_empty_string_disables_thumbs() {
+		$thumb_empty = '';
+
+		$this->assertFalse( ! empty( $thumb_empty ), 'Empty string thumb should be falsy.' );
+	}
+
+	/**
+	 * Test that integer 1 still works for backwards compatibility.
+	 */
+	public function test_thumb_attribute_works_with_integer_value() {
+		$thumb_integer = 1;
+
+		$this->assertTrue( ! empty( $thumb_integer ), 'Integer 1 thumb should be truthy.' );
+	}
+}

--- a/tests/wpunit/LeagueTableThumbTest.php
+++ b/tests/wpunit/LeagueTableThumbTest.php
@@ -1,55 +1,132 @@
 <?php
 /**
- * Tests that the league table shortcode correctly handles string "1"
- * for the thumb attribute (as passed by widgets and shortcode parsing).
+ * Regression tests for league table shortcode thumb attribute handling.
+ *
+ * The PHPCS cleanup in 2.3.1 changed `1 == $thumb` to `1 === $thumb`,
+ * but shortcode attributes are always strings. This caused club logos
+ * to stop rendering because `1 === "1"` is false.
  *
  * @see https://github.com/WPClubManager/wp-club-manager/issues/111
  */
 
 class LeagueTableThumbTest extends WPCMTestCase {
 
+	/** @var int */
+	private $club_id;
+
+	/** @var int */
+	private $table_id;
+
+	/** @var int */
+	private $comp_id;
+
+	/** @var int */
+	private $season_id;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		update_option( 'wpcm_sport', 'soccer' );
+		update_option( 'wpcm_disable_cache', 'yes' );
+		update_option( 'wpcm_standings_columns_display', 'p,w,d,l,pts' );
+
+		$this->club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Thumb Test FC',
+			'post_status' => 'publish',
+		) );
+
+		$comp = wp_insert_term( 'Thumb Test League', 'wpcm_comp' );
+		$this->comp_id = is_wp_error( $comp ) ? $comp->get_error_data() : $comp['term_id'];
+
+		$season = wp_insert_term( 'Thumb Test Season', 'wpcm_season' );
+		$this->season_id = is_wp_error( $season ) ? $season->get_error_data() : $season['term_id'];
+
+		wp_set_object_terms( $this->club_id, $this->comp_id, 'wpcm_comp' );
+		wp_set_object_terms( $this->club_id, $this->season_id, 'wpcm_season' );
+
+		$this->table_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_table',
+			'post_title'  => 'Thumb Test Table',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $this->table_id, '_wpcm_table_clubs', array( $this->club_id ) );
+		update_post_meta( $this->table_id, '_wpcm_table_stats', array() );
+
+		wp_set_object_terms( $this->table_id, $this->comp_id, 'wpcm_comp' );
+		wp_set_object_terms( $this->table_id, $this->season_id, 'wpcm_season' );
+	}
+
+	public function _tearDown() {
+		wp_delete_post( $this->table_id, true );
+		wp_delete_post( $this->club_id, true );
+
+		parent::_tearDown();
+	}
+
 	/**
-	 * Test that the thumb attribute check works with string "1".
+	 * Helper: capture the league table shortcode output.
 	 *
-	 * The PHPCS cleanup in 2.3.1 changed `1 == $thumb` to `1 === $thumb`,
-	 * but shortcode attributes are always strings. This caused club logos
-	 * to stop rendering. The fix uses `! empty( $thumb )` instead.
+	 * @param array $atts Shortcode attributes.
+	 * @return string Rendered HTML.
 	 */
-	public function test_thumb_attribute_works_with_string_value() {
-		// Simulate how the shortcode class processes the thumb attribute.
-		// When passed via shortcode, $thumb is always a string.
-		$thumb_from_shortcode = '1';
-
-		// Before fix: 1 === '1' would be false (bug).
-		// After fix: ! empty( '1' ) is true (correct).
-		$this->assertTrue( ! empty( $thumb_from_shortcode ), 'String "1" thumb should be truthy.' );
+	private function get_league_table_output( $atts ) {
+		ob_start();
+		WPCM_Shortcode_League_Table::output( $atts );
+		return ob_get_clean();
 	}
 
 	/**
-	 * Test that thumb="0" correctly disables thumbnails.
+	 * Regression test: thumb="1" (string from shortcode) should render crests.
+	 *
+	 * Before the fix, `1 === '1'` was false and logos never appeared.
 	 */
-	public function test_thumb_attribute_zero_disables_thumbs() {
-		$thumb_disabled = '0';
+	public function test_thumb_string_one_renders_crest() {
+		$output = $this->get_league_table_output( array(
+			'id'    => $this->table_id,
+			'thumb' => '1',
+		) );
 
-		// "0" is empty in PHP, so ! empty( "0" ) is false - correct behaviour.
-		$this->assertFalse( ! empty( $thumb_disabled ), 'String "0" thumb should be falsy.' );
+		$this->assertStringContainsString( 'crest', $output, 'Shortcode with thumb="1" should render crest markup.' );
 	}
 
 	/**
-	 * Test that thumb="" (empty string) disables thumbnails.
+	 * Test that thumb="0" suppresses crest output.
 	 */
-	public function test_thumb_attribute_empty_string_disables_thumbs() {
-		$thumb_empty = '';
+	public function test_thumb_zero_hides_crest() {
+		$output = $this->get_league_table_output( array(
+			'id'    => $this->table_id,
+			'thumb' => '0',
+		) );
 
-		$this->assertFalse( ! empty( $thumb_empty ), 'Empty string thumb should be falsy.' );
+		$this->assertStringNotContainsString( 'crest', $output, 'Shortcode with thumb="0" should not render crest markup.' );
+	}
+
+	/**
+	 * Test that omitting thumb (empty string) defaults to showing crests
+	 * for non-widget context.
+	 *
+	 * The shortcode normalises empty thumb to 1 when type is not "widget".
+	 */
+	public function test_empty_thumb_defaults_to_showing_crest() {
+		$output = $this->get_league_table_output( array(
+			'id'    => $this->table_id,
+			'thumb' => '',
+		) );
+
+		$this->assertStringContainsString( 'crest', $output, 'Empty thumb attribute should default to showing crests for non-widget type.' );
 	}
 
 	/**
 	 * Test that integer 1 still works for backwards compatibility.
 	 */
-	public function test_thumb_attribute_works_with_integer_value() {
-		$thumb_integer = 1;
+	public function test_thumb_integer_one_renders_crest() {
+		$output = $this->get_league_table_output( array(
+			'id'    => $this->table_id,
+			'thumb' => 1,
+		) );
 
-		$this->assertTrue( ! empty( $thumb_integer ), 'Integer 1 thumb should be truthy.' );
+		$this->assertStringContainsString( 'crest', $output, 'Shortcode with thumb=1 (integer) should render crest markup.' );
 	}
 }


### PR DESCRIPTION
## Summary

- Club logos/badges stopped appearing in the league table widget after the 2.3.1 update
- The PHPCS cleanup (#80) changed `1 == $thumb` to `1 === $thumb`, but shortcode attributes are always strings - so `1 === "1"` is `false` and thumbnails never render
- Fixed by using `! empty($thumb)`, matching the pattern already applied to `$abbr` and `$link_club` in the same files

## Changes

| File | Change |
|------|--------|
| `includes/shortcodes/class-wpcm-shortcode-league-table.php` | `1 === $thumb` → `! empty( $thumb )` |
| `includes/shortcodes/legacy/class-wpcm-shortcode-standings.php` | `1 === $thumb` → `! empty( $thumb )` |
| `tests/wpunit/LeagueTableThumbTest.php` | New test verifying string/int thumb attribute handling |

## Test plan

- [ ] Verify league table widget shows club logos when "Show club badge" is checked
- [ ] Verify logos are hidden when the option is unchecked
- [ ] Verify `[league_table thumb="1"]` shortcode shows logos
- [ ] Verify `[league_table thumb="0"]` shortcode hides logos
- [ ] Run WPUnit tests

Closes #111