### PR TITLE
Release 2.3.3

### DIFF
--- a/includes/shortcodes/class-wpcm-shortcode-league-table.php
+++ b/includes/shortcodes/class-wpcm-shortcode-league-table.php
@@ -104,7 +104,7 @@ class WPCM_Shortcode_League_Table {
 					$total_stats             = get_wpcm_table_total_stats( $club->ID, $comp, $season, $manual_stats[ $club->ID ] );
 					$club->wpcm_stats        = $total_stats;
 				}
-				if ( 1 === $thumb ) {
+				if ( ! empty( $thumb ) ) {
 					if ( has_post_thumbnail( $club->ID ) ) {
 						$club->thumb = get_the_post_thumbnail( $club->ID, 'crest-small' );
 					} else {

--- a/includes/shortcodes/legacy/class-wpcm-shortcode-standings.php
+++ b/includes/shortcodes/legacy/class-wpcm-shortcode-standings.php
@@ -100,7 +100,7 @@ class WPCM_Shortcode_Standings {
 			foreach ( $clubs as $club ) {
 				$club_stats       = get_wpcm_club_total_stats( $club->ID, $comp, $season );
 				$club->wpcm_stats = $club_stats;
-				if ( 1 === $thumb ) {
+				if ( ! empty( $thumb ) ) {
 					if ( has_post_thumbnail( $club->ID ) ) {
 						$club->thumb = get_the_post_thumbnail( $club->ID, 'crest-small' );
 					} else {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wp-club-manager",
   "title": "WP Club Manager",
   "description": "Plugin",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "homepage": "https://wpclubmanager.com",
   "author": {
     "name": "WP Club Manager",

--- a/readme.txt
+++ b/readme.txt
@@ -173,18 +173,16 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 2.3.2 - 8th April 2026 =
 
-* Fix: Sub appearances count showing incorrectly (#84)
-* Fix: PHP 8.x fatal error - array_merge null argument in settings (#109)
-* Fix: Players List and Standings widgets render empty (#103)
-* Fix: PHP 8.x fatal errors from null property access (#93)
-* Fix: Allow multiple players per user account (#101)
-* Fix: Anchor vendor pattern in .distignore to preserve JS assets (#105)
-* Add: WPCM constants stub for PHPStan (#107)
+* Fix: Sub appearances count showing incorrectly
+* Fix: PHP 8.x fatal error on player settings page
+* Fix: Players List and Standings widgets rendering empty
+* Fix: PHP 8.x fatal errors from null property access in dashboard and stats
+* Fix: Allow multiple players to be linked to a single user account
+* Fix: Missing JavaScript assets in WordPress.org release
 
 = 2.3.1 - 6th April 2026 =
 
-* Fix: Exclude dev files from Grunt build (phpstan, composer, release.json, etc)
-* Chore: Resolve all PHPCS warnings
+* Tweak: Internal code quality improvements
 
 = 2.3.0 - 2nd April 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Requires at least: 4.9
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable Tag: 2.3.2
+Stable Tag: 2.3.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -170,6 +170,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 11. Front-end League Table
 
 == Changelog ==
+
+= 2.3.3 - 13th April 2026 =
+
+* Fix: League table club logos not showing after 2.3.1
 
 = 2.3.2 - 8th April 2026 =
 

--- a/tests/wpunit/LeagueTableThumbTest.php
+++ b/tests/wpunit/LeagueTableThumbTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Regression tests for league table shortcode thumb attribute handling.
+ *
+ * The PHPCS cleanup in 2.3.1 changed `1 == $thumb` to `1 === $thumb`,
+ * but shortcode attributes are always strings. This caused club logos
+ * to stop rendering because `1 === "1"` is false.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/111
+ */
+
+class LeagueTableThumbTest extends WPCMTestCase {
+
+	/** @var int */
+	private $club_id;
+
+	/** @var int */
+	private $table_id;
+
+	/** @var int */
+	private $comp_id;
+
+	/** @var int */
+	private $season_id;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		update_option( 'wpcm_sport', 'soccer' );
+		update_option( 'wpcm_disable_cache', 'yes' );
+		update_option( 'wpcm_standings_columns_display', 'p,w,d,l,pts' );
+
+		$this->club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Thumb Test FC',
+			'post_status' => 'publish',
+		) );
+
+		$comp = wp_insert_term( 'Thumb Test League', 'wpcm_comp' );
+		$this->comp_id = is_wp_error( $comp ) ? $comp->get_error_data() : $comp['term_id'];
+
+		$season = wp_insert_term( 'Thumb Test Season', 'wpcm_season' );
+		$this->season_id = is_wp_error( $season ) ? $season->get_error_data() : $season['term_id'];
+
+		wp_set_object_terms( $this->club_id, $this->comp_id, 'wpcm_comp' );
+		wp_set_object_terms( $this->club_id, $this->season_id, 'wpcm_season' );
+
+		$this->table_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_table',
+			'post_title'  => 'Thumb Test Table',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $this->table_id, '_wpcm_table_clubs', array( $this->club_id ) );
+		update_post_meta( $this->table_id, '_wpcm_table_stats', array() );
+
+		wp_set_object_terms( $this->table_id, $this->comp_id, 'wpcm_comp' );
+		wp_set_object_terms( $this->table_id, $this->season_id, 'wpcm_season' );
+	}
+
+	public function _tearDown() {
+		wp_delete_post( $this->table_id, true );
+		wp_delete_post( $this->club_id, true );
+
+		parent::_tearDown();
+	}
+
+	/**
+	 * Helper: capture the league table shortcode output.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string Rendered HTML.
+	 */
+	private function get_league_table_output( $atts ) {
+		ob_start();
+		WPCM_Shortcode_League_Table::output( $atts );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Regression test: thumb="1" (string from shortcode) should render crests.
+	 *
+	 * Before the fix, `1 === '1'` was false and logos never appeared.
+	 */
+	public function test_thumb_string_one_renders_crest() {
+		$output = $this->get_league_table_output( array(
+			'id'    => $this->table_id,
+			'thumb' => '1',
+		) );
+
+		$this->assertStringContainsString( 'crest', $output, 'Shortcode with thumb="1" should render crest markup.' );
+	}
+
+	/**
+	 * Test that thumb="0" suppresses crest output.
+	 */
+	public function test_thumb_zero_hides_crest() {
+		$output = $this->get_league_table_output( array(
+			'id'    => $this->table_id,
+			'thumb' => '0',
+		) );
+
+		$this->assertStringNotContainsString( 'crest', $output, 'Shortcode with thumb="0" should not render crest markup.' );
+	}
+
+	/**
+	 * Test that omitting thumb (empty string) defaults to showing crests
+	 * for non-widget context.
+	 *
+	 * The shortcode normalises empty thumb to 1 when type is not "widget".
+	 */
+	public function test_empty_thumb_defaults_to_showing_crest() {
+		$output = $this->get_league_table_output( array(
+			'id'    => $this->table_id,
+			'thumb' => '',
+		) );
+
+		$this->assertStringContainsString( 'crest', $output, 'Empty thumb attribute should default to showing crests for non-widget type.' );
+	}
+
+	/**
+	 * Test that integer 1 still works for backwards compatibility.
+	 */
+	public function test_thumb_integer_one_renders_crest() {
+		$output = $this->get_league_table_output( array(
+			'id'    => $this->table_id,
+			'thumb' => 1,
+		) );
+
+		$this->assertStringContainsString( 'crest', $output, 'Shortcode with thumb=1 (integer) should render crest markup.' );
+	}
+}

--- a/wpclubmanager.php
+++ b/wpclubmanager.php
@@ -6,7 +6,7 @@
  * Author: WP Club Manager
  * Author URI: https://wpclubmanager.com
  * Requires PHP: 7.4
- * Version: 2.3.2
+ * Version: 2.3.3
  * Text Domain: wp-club-manager
  * Domain Path: /languages/
  * License: GPLv3
@@ -27,7 +27,7 @@ if ( ! function_exists( 'WPCM' ) ) :
 	function WPCM() {
 		require_once __DIR__ . '/includes/class-wp-club-manager.php';
 
-		return WP_Club_Manager::instance( __FILE__, '2.3.2' );
+		return WP_Club_Manager::instance( __FILE__, '2.3.3' );
 	}
 endif;
 


### PR DESCRIPTION
## Summary

- Fix: League table club logos not showing after 2.3.1 (#111)
- Fix: Clean up changelog entries for 2.3.2

## Changelog

### 2.3.3 - 13th April 2026

* Fix: League table club logos not showing after 2.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)