### PR TITLE
[Feature] Include all settings in export/import (#99)

### DIFF
--- a/includes/admin/class-wpcm-admin-settings.php
+++ b/includes/admin/class-wpcm-admin-settings.php
@@ -51,6 +51,7 @@ if ( ! class_exists( 'WPCM_Admin_Settings' ) ) :
 				if ( in_array( 'wpcm-player-appearances/wpcm-player-appearances.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) || in_array( 'wpcm-players-gallery/wpcm-player-gallery.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) || in_array( 'wpcm-sponsors-pro/wpcm-sponsors-pro.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
 					$settings[] = include 'settings/class-wpcm-settings-licenses.php';
 				}
+				$settings[] = include 'settings/class-wpcm-settings-tools.php';
 
 				self::$settings = apply_filters( 'wpclubmanager_get_settings_pages', $settings );
 			}

--- a/includes/admin/settings/class-wpcm-settings-tools.php
+++ b/includes/admin/settings/class-wpcm-settings-tools.php
@@ -29,6 +29,9 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 			'wpclubmanager_installed',
 			'wpcm_version_upgraded_from',
 			'wpclubmanager_admin_footer_text_rated',
+			'wpcm_transient_keys',
+			'wpclubmanager_admin_notices',
+			'wpclubmanager_meta_box_errors',
 		);
 
 		/**
@@ -41,7 +44,7 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 			add_filter( 'wpclubmanager_settings_tabs_array', array( $this, 'add_settings_page' ), 99 );
 			add_action( 'wpclubmanager_settings_' . $this->id, array( $this, 'output' ) );
 			add_action( 'wpclubmanager_settings_save_' . $this->id, array( $this, 'save' ) );
-			add_action( 'admin_init', array( $this, 'handle_export' ) );
+			add_action( 'admin_post_wpcm_export_settings', array( $this, 'handle_export' ) );
 		}
 
 		/**
@@ -120,7 +123,7 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 		public static function validate_import_json( $json ) {
 			$data = json_decode( $json, true );
 
-			if ( null === $data ) {
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
 				return new WP_Error(
 					'invalid_json',
 					__( 'The uploaded file does not contain valid JSON.', 'wp-club-manager' )
@@ -141,7 +144,7 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 		 * Import settings from an associative array.
 		 *
 		 * @param array $data Settings data to import.
-		 * @return bool True on success, false if data is empty.
+		 * @return bool True on success, false if no valid settings were imported.
 		 */
 		public static function import_settings( $data ) {
 			if ( empty( $data ) ) {
@@ -162,19 +165,10 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 		}
 
 		/**
-		 * Handle the export action via GET request.
+		 * Handle the export action via admin-post.php.
 		 */
 		public function handle_export() {
-			$action = filter_input( INPUT_GET, 'action', FILTER_UNSAFE_RAW );
-			$nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_UNSAFE_RAW );
-
-			if ( 'wpcm_export_settings' !== $action ) {
-				return;
-			}
-
-			if ( empty( $nonce ) || ! wp_verify_nonce( sanitize_text_field( $nonce ), 'wpcm-export-settings' ) ) {
-				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'wp-club-manager' ) );
-			}
+			check_admin_referer( 'wpcm-export-settings' );
 
 			if ( ! current_user_can( 'manage_wpclubmanager' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
 				wp_die( esc_html__( 'You do not have permission to export settings.', 'wp-club-manager' ) );
@@ -217,8 +211,19 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 				return;
 			}
 
-			$tmp_name = sanitize_text_field( $file['tmp_name'] );
-			$json     = file_get_contents( $tmp_name ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$tmp_name = wp_unslash( $file['tmp_name'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+			if ( ! is_uploaded_file( $tmp_name ) ) {
+				WPCM_Admin_Settings::add_error( __( 'The uploaded file could not be read. Please try again.', 'wp-club-manager' ) );
+				return;
+			}
+
+			$json = file_get_contents( $tmp_name ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+			if ( false === $json ) {
+				WPCM_Admin_Settings::add_error( __( 'The uploaded file could not be read. Please try again.', 'wp-club-manager' ) );
+				return;
+			}
 
 			$data = self::validate_import_json( $json );
 
@@ -252,7 +257,7 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 			$GLOBALS['hide_save_button'] = true;
 
 			$export_url = wp_nonce_url(
-				admin_url( 'admin.php?page=wpcm-settings&tab=tools&action=wpcm_export_settings' ),
+				admin_url( 'admin-post.php?action=wpcm_export_settings' ),
 				'wpcm-export-settings'
 			);
 			?>

--- a/includes/admin/settings/class-wpcm-settings-tools.php
+++ b/includes/admin/settings/class-wpcm-settings-tools.php
@@ -53,9 +53,11 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 			global $wpdb;
 
 			$results = $wpdb->get_col(
-				"SELECT option_name FROM {$wpdb->options}
-				WHERE option_name LIKE 'wpcm\_%'
-				OR option_name LIKE 'wpclubmanager\_%'"
+				$wpdb->prepare(
+					"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+					$wpdb->esc_like( 'wpcm_' ) . '%',
+					$wpdb->esc_like( 'wpclubmanager_' ) . '%'
+				)
 			);
 
 			return is_array( $results ) ? $results : array();
@@ -73,6 +75,20 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 			}
 
 			return ( strpos( $option_name, 'wpcm_' ) === 0 || strpos( $option_name, 'wpclubmanager_' ) === 0 );
+		}
+
+		/**
+		 * Sanitize a value for import.
+		 *
+		 * @param mixed $value Value to clean.
+		 * @return mixed
+		 */
+		private static function clean_value( $value ) {
+			if ( is_array( $value ) ) {
+				return array_map( array( __CLASS__, 'clean_value' ), $value );
+			}
+
+			return is_string( $value ) ? wpcm_clean( $value ) : $value;
 		}
 
 		/**
@@ -132,13 +148,17 @@ if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
 				return false;
 			}
 
+			$updated = 0;
+
 			foreach ( $data as $name => $value ) {
 				if ( self::is_valid_option( $name ) ) {
+					$value = self::clean_value( $value );
 					update_option( $name, $value );
+					++$updated;
 				}
 			}
 
-			return true;
+			return $updated > 0;
 		}
 
 		/**

--- a/includes/admin/settings/class-wpcm-settings-tools.php
+++ b/includes/admin/settings/class-wpcm-settings-tools.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * WPClubManager Tools Settings (Export/Import)
+ *
+ * @author      ClubPress
+ * @category    Admin
+ * @package     WPClubManager/Admin
+ * @version     2.4.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
+
+	/**
+	 * WPCM_Settings_Tools
+	 */
+	class WPCM_Settings_Tools extends WPCM_Settings_Page {
+
+		/**
+		 * Options that should not be exported or imported.
+		 *
+		 * @var array
+		 */
+		private static $excluded_options = array(
+			'wpclubmanager_version',
+			'wpclubmanager_installed',
+			'wpcm_version_upgraded_from',
+			'wpclubmanager_admin_footer_text_rated',
+		);
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id    = 'tools';
+			$this->label = __( 'Tools', 'wp-club-manager' );
+
+			add_filter( 'wpclubmanager_settings_tabs_array', array( $this, 'add_settings_page' ), 99 );
+			add_action( 'wpclubmanager_settings_' . $this->id, array( $this, 'output' ) );
+			add_action( 'wpclubmanager_settings_save_' . $this->id, array( $this, 'save' ) );
+			add_action( 'admin_init', array( $this, 'handle_export' ) );
+		}
+
+		/**
+		 * Get all WPCM option names from the database.
+		 *
+		 * @return array
+		 */
+		private static function get_wpcm_option_names() {
+			global $wpdb;
+
+			$results = $wpdb->get_col(
+				"SELECT option_name FROM {$wpdb->options}
+				WHERE option_name LIKE 'wpcm\_%'
+				OR option_name LIKE 'wpclubmanager\_%'"
+			);
+
+			return is_array( $results ) ? $results : array();
+		}
+
+		/**
+		 * Check if an option name is a valid WPCM setting.
+		 *
+		 * @param string $option_name Option name to check.
+		 * @return bool
+		 */
+		private static function is_valid_option( $option_name ) {
+			if ( in_array( $option_name, self::$excluded_options, true ) ) {
+				return false;
+			}
+
+			return ( strpos( $option_name, 'wpcm_' ) === 0 || strpos( $option_name, 'wpclubmanager_' ) === 0 );
+		}
+
+		/**
+		 * Get export data as an associative array.
+		 *
+		 * @return array
+		 */
+		public static function get_export_data() {
+			$option_names = self::get_wpcm_option_names();
+			$data         = array();
+
+			foreach ( $option_names as $name ) {
+				if ( self::is_valid_option( $name ) ) {
+					$data[ $name ] = get_option( $name );
+				}
+			}
+
+			ksort( $data );
+
+			return $data;
+		}
+
+		/**
+		 * Validate import JSON string.
+		 *
+		 * @param string $json JSON string to validate.
+		 * @return array|WP_Error Decoded data array on success, WP_Error on failure.
+		 */
+		public static function validate_import_json( $json ) {
+			$data = json_decode( $json, true );
+
+			if ( null === $data ) {
+				return new WP_Error(
+					'invalid_json',
+					__( 'The uploaded file does not contain valid JSON.', 'wp-club-manager' )
+				);
+			}
+
+			if ( ! is_array( $data ) || empty( $data ) ) {
+				return new WP_Error(
+					'invalid_format',
+					__( 'The uploaded file does not contain valid settings data.', 'wp-club-manager' )
+				);
+			}
+
+			return $data;
+		}
+
+		/**
+		 * Import settings from an associative array.
+		 *
+		 * @param array $data Settings data to import.
+		 * @return bool True on success, false if data is empty.
+		 */
+		public static function import_settings( $data ) {
+			if ( empty( $data ) ) {
+				return false;
+			}
+
+			foreach ( $data as $name => $value ) {
+				if ( self::is_valid_option( $name ) ) {
+					update_option( $name, $value );
+				}
+			}
+
+			return true;
+		}
+
+		/**
+		 * Handle the export action via GET request.
+		 */
+		public function handle_export() {
+			$action = filter_input( INPUT_GET, 'action', FILTER_UNSAFE_RAW );
+			$nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_UNSAFE_RAW );
+
+			if ( 'wpcm_export_settings' !== $action ) {
+				return;
+			}
+
+			if ( empty( $nonce ) || ! wp_verify_nonce( sanitize_text_field( $nonce ), 'wpcm-export-settings' ) ) {
+				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'wp-club-manager' ) );
+			}
+
+			if ( ! current_user_can( 'manage_wpclubmanager' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You do not have permission to export settings.', 'wp-club-manager' ) );
+			}
+
+			$data     = self::get_export_data();
+			$filename = 'wpcm-settings-' . gmdate( 'Y-m-d' ) . '.json';
+
+			nocache_headers();
+			header( 'Content-Type: application/json; charset=utf-8' );
+			header( 'Content-Disposition: attachment; filename=' . $filename );
+			header( 'Expires: 0' );
+
+			echo wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
+			exit;
+		}
+
+		/**
+		 * Save / process import.
+		 */
+		public function save() {
+			$nonce = filter_input( INPUT_POST, '_wpnonce', FILTER_UNSAFE_RAW );
+			if ( empty( $nonce ) || ! wp_verify_nonce( sanitize_text_field( $nonce ), 'wpclubmanager-settings' ) ) {
+				return;
+			}
+
+			if ( ! current_user_can( 'manage_wpclubmanager' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				return;
+			}
+
+			if ( empty( $_FILES['wpcm_import_file'] ) || empty( $_FILES['wpcm_import_file']['tmp_name'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+				WPCM_Admin_Settings::add_error( __( 'Please select a JSON file to import.', 'wp-club-manager' ) );
+				return;
+			}
+
+			$file = $_FILES['wpcm_import_file']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+
+			if ( ! empty( $file['error'] ) ) {
+				WPCM_Admin_Settings::add_error( __( 'There was an error uploading the file. Please try again.', 'wp-club-manager' ) );
+				return;
+			}
+
+			$tmp_name = sanitize_text_field( $file['tmp_name'] );
+			$json     = file_get_contents( $tmp_name ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+			$data = self::validate_import_json( $json );
+
+			if ( is_wp_error( $data ) ) {
+				WPCM_Admin_Settings::add_error( $data->get_error_message() );
+				return;
+			}
+
+			$result = self::import_settings( $data );
+
+			if ( $result ) {
+				WPCM_Admin_Settings::add_message( __( 'Settings imported successfully.', 'wp-club-manager' ) );
+			} else {
+				WPCM_Admin_Settings::add_error( __( 'No valid settings found in the uploaded file.', 'wp-club-manager' ) );
+			}
+		}
+
+		/**
+		 * Get settings array (empty — this tab uses custom output).
+		 *
+		 * @return array
+		 */
+		public function get_settings() {
+			return array();
+		}
+
+		/**
+		 * Output the tools page.
+		 */
+		public function output() {
+			$GLOBALS['hide_save_button'] = true;
+
+			$export_url = wp_nonce_url(
+				admin_url( 'admin.php?page=wpcm-settings&tab=tools&action=wpcm_export_settings' ),
+				'wpcm-export-settings'
+			);
+			?>
+			<div class="stuffbox">
+				<h3><?php esc_html_e( 'Export Settings', 'wp-club-manager' ); ?></h3>
+				<div class="inside">
+					<p><?php esc_html_e( 'Export your WP Club Manager settings as a JSON file. This can be used to transfer your settings to another site.', 'wp-club-manager' ); ?></p>
+					<p>
+						<a href="<?php echo esc_url( $export_url ); ?>" class="button">
+							<?php esc_html_e( 'Export Settings', 'wp-club-manager' ); ?>
+						</a>
+					</p>
+				</div>
+			</div>
+
+			<div class="stuffbox">
+				<h3><?php esc_html_e( 'Import Settings', 'wp-club-manager' ); ?></h3>
+				<div class="inside">
+					<p><?php esc_html_e( 'Import WP Club Manager settings from a previously exported JSON file. This will overwrite your current settings.', 'wp-club-manager' ); ?></p>
+					<table class="form-table">
+						<tr>
+							<th scope="row" class="titledesc">
+								<label for="wpcm_import_file"><?php esc_html_e( 'Settings File', 'wp-club-manager' ); ?></label>
+							</th>
+							<td class="forminp">
+								<input type="file" name="wpcm_import_file" id="wpcm_import_file" accept=".json" />
+								<span class="description"><?php esc_html_e( 'Upload a .json file previously exported from WP Club Manager.', 'wp-club-manager' ); ?></span>
+							</td>
+						</tr>
+					</table>
+					<p class="submit">
+						<input name="save" class="button-primary" type="submit" value="<?php esc_html_e( 'Import Settings', 'wp-club-manager' ); ?>" />
+					</p>
+				</div>
+			</div>
+			<?php
+		}
+	}
+
+endif;
+
+return new WPCM_Settings_Tools();

--- a/tests/wpunit/SettingsExportImportTest.php
+++ b/tests/wpunit/SettingsExportImportTest.php
@@ -80,6 +80,9 @@ class SettingsExportImportTest extends WPCMTestCase {
 		$this->set_option( 'wpclubmanager_installed', '1' );
 		$this->set_option( 'wpcm_version_upgraded_from', '2.3.0' );
 		$this->set_option( 'wpclubmanager_admin_footer_text_rated', '1' );
+		$this->set_option( 'wpcm_transient_keys', array( 'key1' ) );
+		$this->set_option( 'wpclubmanager_admin_notices', array( 'notice1' ) );
+		$this->set_option( 'wpclubmanager_meta_box_errors', array( 'error1' ) );
 
 		$exported = WPCM_Settings_Tools::get_export_data();
 
@@ -87,6 +90,9 @@ class SettingsExportImportTest extends WPCMTestCase {
 		$this->assertArrayNotHasKey( 'wpclubmanager_installed', $exported );
 		$this->assertArrayNotHasKey( 'wpcm_version_upgraded_from', $exported );
 		$this->assertArrayNotHasKey( 'wpclubmanager_admin_footer_text_rated', $exported );
+		$this->assertArrayNotHasKey( 'wpcm_transient_keys', $exported );
+		$this->assertArrayNotHasKey( 'wpclubmanager_admin_notices', $exported );
+		$this->assertArrayNotHasKey( 'wpclubmanager_meta_box_errors', $exported );
 	}
 
 	public function test_export_excludes_non_wpcm_options() {

--- a/tests/wpunit/SettingsExportImportTest.php
+++ b/tests/wpunit/SettingsExportImportTest.php
@@ -20,6 +20,18 @@ class SettingsExportImportTest extends WPCMTestCase {
 	public function _setUp() {
 		parent::_setUp();
 		$this->test_options = array();
+
+		if ( ! class_exists( 'WPCM_Settings_Page' ) ) {
+			include_once WPCM_PATH . 'includes/admin/settings/class-wpcm-settings-page.php';
+		}
+
+		if ( ! class_exists( 'WPCM_Admin_Settings' ) ) {
+			include_once WPCM_PATH . 'includes/admin/class-wpcm-admin-settings.php';
+		}
+
+		if ( ! class_exists( 'WPCM_Settings_Tools' ) ) {
+			include_once WPCM_PATH . 'includes/admin/settings/class-wpcm-settings-tools.php';
+		}
 	}
 
 	public function _tearDown() {

--- a/tests/wpunit/SettingsExportImportTest.php
+++ b/tests/wpunit/SettingsExportImportTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Tests for settings export/import functionality.
+ *
+ * Verifies that WPCM settings can be exported to JSON and
+ * imported back, preserving all option values.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/99
+ */
+
+class SettingsExportImportTest extends WPCMTestCase {
+
+	/**
+	 * Options to clean up after each test.
+	 *
+	 * @var array
+	 */
+	private $test_options = array();
+
+	public function _setUp() {
+		parent::_setUp();
+		$this->test_options = array();
+	}
+
+	public function _tearDown() {
+		foreach ( $this->test_options as $option ) {
+			delete_option( $option );
+		}
+		parent::_tearDown();
+	}
+
+	/**
+	 * Helper to set a test option and track it for cleanup.
+	 */
+	private function set_option( $name, $value ) {
+		update_option( $name, $value );
+		$this->test_options[] = $name;
+	}
+
+	// -------------------------------------------------------------------
+	// Export
+	// -------------------------------------------------------------------
+
+	public function test_export_returns_array_of_wpcm_options() {
+		$this->set_option( 'wpcm_sport', 'soccer' );
+		$this->set_option( 'wpcm_mode', 'club' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertIsArray( $exported );
+		$this->assertArrayHasKey( 'wpcm_sport', $exported );
+		$this->assertArrayHasKey( 'wpcm_mode', $exported );
+		$this->assertEquals( 'soccer', $exported['wpcm_sport'] );
+		$this->assertEquals( 'club', $exported['wpcm_mode'] );
+	}
+
+	public function test_export_includes_wpclubmanager_prefixed_options() {
+		$this->set_option( 'wpclubmanager_player_slug', 'players' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertArrayHasKey( 'wpclubmanager_player_slug', $exported );
+		$this->assertEquals( 'players', $exported['wpclubmanager_player_slug'] );
+	}
+
+	public function test_export_excludes_internal_options() {
+		$this->set_option( 'wpclubmanager_version', '2.3.3' );
+		$this->set_option( 'wpclubmanager_installed', '1' );
+		$this->set_option( 'wpcm_version_upgraded_from', '2.3.0' );
+		$this->set_option( 'wpclubmanager_admin_footer_text_rated', '1' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertArrayNotHasKey( 'wpclubmanager_version', $exported );
+		$this->assertArrayNotHasKey( 'wpclubmanager_installed', $exported );
+		$this->assertArrayNotHasKey( 'wpcm_version_upgraded_from', $exported );
+		$this->assertArrayNotHasKey( 'wpclubmanager_admin_footer_text_rated', $exported );
+	}
+
+	public function test_export_excludes_non_wpcm_options() {
+		$this->set_option( 'blogname', 'Test Site' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertArrayNotHasKey( 'blogname', $exported );
+	}
+
+	public function test_export_handles_serialized_values() {
+		$array_value = array( 'p', 'w', 'd', 'l', 'f', 'a', 'gd', 'pts' );
+		$this->set_option( 'wpcm_standings_columns_display', $array_value );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertArrayHasKey( 'wpcm_standings_columns_display', $exported );
+		$this->assertEquals( $array_value, $exported['wpcm_standings_columns_display'] );
+	}
+
+	// -------------------------------------------------------------------
+	// Import
+	// -------------------------------------------------------------------
+
+	public function test_import_restores_options_from_valid_data() {
+		$import_data = array(
+			'wpcm_sport'           => 'rugby',
+			'wpcm_mode'            => 'league',
+			'wpcm_default_country' => 'GB',
+		);
+
+		$result = WPCM_Settings_Tools::import_settings( $import_data );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( 'rugby', get_option( 'wpcm_sport' ) );
+		$this->assertEquals( 'league', get_option( 'wpcm_mode' ) );
+		$this->assertEquals( 'GB', get_option( 'wpcm_default_country' ) );
+
+		$this->test_options = array_merge( $this->test_options, array_keys( $import_data ) );
+	}
+
+	public function test_import_rejects_non_wpcm_keys() {
+		$import_data = array(
+			'wpcm_sport'   => 'soccer',
+			'blogname'     => 'Hacked Site',
+			'admin_email'  => 'evil@example.com',
+		);
+
+		WPCM_Settings_Tools::import_settings( $import_data );
+
+		$this->assertEquals( 'soccer', get_option( 'wpcm_sport' ) );
+		$this->assertNotEquals( 'Hacked Site', get_option( 'blogname' ) );
+		$this->assertNotEquals( 'evil@example.com', get_option( 'admin_email' ) );
+
+		$this->test_options[] = 'wpcm_sport';
+	}
+
+	public function test_import_rejects_internal_options() {
+		$original_version = get_option( 'wpclubmanager_version' );
+
+		$import_data = array(
+			'wpclubmanager_version'   => '9.9.9',
+			'wpclubmanager_installed' => '0',
+		);
+
+		WPCM_Settings_Tools::import_settings( $import_data );
+
+		$this->assertEquals( $original_version, get_option( 'wpclubmanager_version' ) );
+	}
+
+	public function test_import_handles_array_values() {
+		$import_data = array(
+			'wpcm_standings_columns_display' => array( 'p', 'w', 'd', 'l', 'pts' ),
+		);
+
+		$result = WPCM_Settings_Tools::import_settings( $import_data );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( array( 'p', 'w', 'd', 'l', 'pts' ), get_option( 'wpcm_standings_columns_display' ) );
+
+		$this->test_options[] = 'wpcm_standings_columns_display';
+	}
+
+	public function test_import_returns_false_for_empty_data() {
+		$result = WPCM_Settings_Tools::import_settings( array() );
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------
+	// Round-trip
+	// -------------------------------------------------------------------
+
+	public function test_export_then_import_preserves_settings() {
+		$this->set_option( 'wpcm_sport', 'hockey' );
+		$this->set_option( 'wpcm_mode', 'club' );
+		$this->set_option( 'wpcm_standings_win_points', '4' );
+		$this->set_option( 'wpcm_map_select', 'osm' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		// Change settings.
+		update_option( 'wpcm_sport', 'soccer' );
+		update_option( 'wpcm_mode', 'league' );
+		update_option( 'wpcm_standings_win_points', '3' );
+		update_option( 'wpcm_map_select', 'google' );
+
+		// Import the original export.
+		WPCM_Settings_Tools::import_settings( $exported );
+
+		$this->assertEquals( 'hockey', get_option( 'wpcm_sport' ) );
+		$this->assertEquals( 'club', get_option( 'wpcm_mode' ) );
+		$this->assertEquals( '4', get_option( 'wpcm_standings_win_points' ) );
+		$this->assertEquals( 'osm', get_option( 'wpcm_map_select' ) );
+	}
+
+	// -------------------------------------------------------------------
+	// JSON encoding
+	// -------------------------------------------------------------------
+
+	public function test_export_data_is_json_encodable() {
+		$this->set_option( 'wpcm_sport', 'soccer' );
+		$this->set_option( 'wpcm_mode', 'club' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+		$json     = wp_json_encode( $exported );
+
+		$this->assertNotFalse( $json );
+
+		$decoded = json_decode( $json, true );
+		$this->assertEquals( $exported, $decoded );
+	}
+
+	public function test_validate_import_json_rejects_invalid_json() {
+		$result = WPCM_Settings_Tools::validate_import_json( 'not valid json{{{' );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	public function test_validate_import_json_rejects_non_object_json() {
+		$result = WPCM_Settings_Tools::validate_import_json( '"just a string"' );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	public function test_validate_import_json_accepts_valid_settings() {
+		$json = wp_json_encode( array( 'wpcm_sport' => 'soccer' ) );
+
+		$result = WPCM_Settings_Tools::validate_import_json( $json );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'wpcm_sport', $result );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a new **Tools** settings tab with export/import functionality for all WPCM plugin settings
- Users can export all `wpcm_*` and `wpclubmanager_*` options as a downloadable JSON file
- Users can import settings from a previously exported JSON file, restoring their configuration on a new site
- Internal options (version, installed flag) are excluded from export/import for safety
- Non-WPCM options are rejected during import to prevent tampering

Closes #99

## Changes

| File | Change |
|------|--------|
| `includes/admin/settings/class-wpcm-settings-tools.php` | New settings page class with export/import logic |
| `includes/admin/class-wpcm-admin-settings.php` | Register the new Tools settings tab |
| `tests/wpunit/SettingsExportImportTest.php` | Unit tests for export, import, validation, and round-trip |

## Test plan

- [ ] Navigate to Club Manager > Settings > Tools tab
- [ ] Click "Export Settings" and verify a JSON file downloads
- [ ] Verify the JSON contains `wpcm_*` options but not `wpclubmanager_version`
- [ ] Change some settings, then import the previously exported JSON
- [ ] Verify settings are restored to their original values
- [ ] Try importing an invalid (non-JSON) file and verify error message
- [ ] Verify non-WPCM keys in a crafted JSON file are rejected
- [ ] WPUnit tests pass for SettingsExportImportTest