### PR TITLE
[Feature] Head-to-head sorting in league tables (#98)

### DIFF
--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -336,7 +336,9 @@ class WPCM_Admin_Dashboard {
 							}
 						}
 
+						wpcm_set_h2h_context( $comp, $season_id );
 						usort( $clubs, 'wpcm_sort_table_clubs' );
+						wpcm_clear_h2h_context();
 
 						if ( 'ASC' === $order ) {
 							$clubs = array_reverse( $clubs );
@@ -493,7 +495,9 @@ class WPCM_Admin_Dashboard {
 							}
 						}
 
+						wpcm_set_h2h_context( $comp, $season_id );
 						usort( $clubs, 'wpcm_sort_table_clubs' );
+						wpcm_clear_h2h_context();
 
 						if ( 'ASC' === $order ) {
 							$clubs = array_reverse( $clubs );

--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-table-stats.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-table-stats.php
@@ -117,7 +117,9 @@ class WPCM_Meta_Box_Table_Stats {
 			}
 		}
 
+		wpcm_set_h2h_context( $comp, $season );
 		usort( $clubs, 'wpcm_sort_table_clubs' );
+		wpcm_clear_h2h_context();
 
 		if ( 'ASC' === $order ) {
 			$clubs = array_reverse( $clubs );

--- a/includes/admin/settings/class-wpcm-settings-standings.php
+++ b/includes/admin/settings/class-wpcm-settings-standings.php
@@ -138,7 +138,8 @@ if ( ! class_exists( 'WPCM_Settings_Standings' ) ) :
 			);
 
 			$stats_names = wpcm_get_preset_labels( 'standings', 'name' );
-			$options = $stats_names;
+			$options         = $stats_names;
+			$options['h2h']  = __( 'Head-to-Head Record', 'wp-club-manager' );
 
 			$settings[] = array(
 				'title'    => __( 'Priority 1', 'wp-club-manager' ),

--- a/includes/shortcodes/class-wpcm-shortcode-league-table.php
+++ b/includes/shortcodes/class-wpcm-shortcode-league-table.php
@@ -115,7 +115,9 @@ class WPCM_Shortcode_League_Table {
 				}
 			}
 
+			wpcm_set_h2h_context( $comp, $season );
 			usort( $clubs, 'wpcm_sort_table_clubs' );
+			wpcm_clear_h2h_context();
 
 			if ( 'ASC' === $order ) {
 				$clubs = array_reverse( $clubs );

--- a/includes/wpcm-standings-functions.php
+++ b/includes/wpcm-standings-functions.php
@@ -225,67 +225,110 @@ if ( ! function_exists( 'get_wpcm_table_total_stats' ) ) {
 	}
 }
 
-/**
- * Store competition and season context for head-to-head lookups during sorting.
- *
- * @param int $comp   Competition term ID.
- * @param int $season Season term ID.
- */
-function wpcm_set_h2h_context( $comp, $season ) {
-	global $wpcm_h2h_comp, $wpcm_h2h_season;
-	$wpcm_h2h_comp   = $comp;
-	$wpcm_h2h_season = $season;
+if ( ! function_exists( 'wpcm_set_h2h_context' ) ) {
+	/**
+	 * Store competition and season context for head-to-head lookups during sorting.
+	 *
+	 * @param int $comp   Competition term ID.
+	 * @param int $season Season term ID.
+	 */
+	function wpcm_set_h2h_context( $comp, $season ) {
+		global $wpcm_h2h_comp, $wpcm_h2h_season;
+		$wpcm_h2h_comp   = $comp;
+		$wpcm_h2h_season = $season;
+	}
 }
 
-/**
- * Clear H2H context and in-memory cache after sorting is complete.
- */
-function wpcm_clear_h2h_context() {
-	global $wpcm_h2h_comp, $wpcm_h2h_season;
-	$wpcm_h2h_comp   = null;
-	$wpcm_h2h_season = null;
-	wpcm_h2h_cache_reset();
+if ( ! function_exists( 'wpcm_clear_h2h_context' ) ) {
+	/**
+	 * Clear H2H context and in-memory cache after sorting is complete.
+	 */
+	function wpcm_clear_h2h_context() {
+		global $wpcm_h2h_comp, $wpcm_h2h_season;
+		$wpcm_h2h_comp   = null;
+		$wpcm_h2h_season = null;
+		wpcm_h2h_cache_reset();
+	}
 }
 
-/**
- * Reset the in-memory H2H results cache.
- */
-function wpcm_h2h_cache_reset() {
-	global $wpcm_h2h_cache;
-	$wpcm_h2h_cache = array();
-}
-
-/**
- * Calculate head-to-head record between two clubs in the current H2H context.
- *
- * Results are cached in-memory for the duration of the request to avoid
- * repeated database queries when called from a usort comparator.
- *
- * Returns points, goal difference, and goals scored for each club
- * based only on their direct matches in the given competition and season.
- *
- * @param int $club_a_id Club A post ID.
- * @param int $club_b_id Club B post ID.
- * @return array {
- *     @type int $a_points Points earned by club A in H2H matches.
- *     @type int $b_points Points earned by club B in H2H matches.
- *     @type int $a_gd     Goal difference for club A in H2H matches.
- *     @type int $b_gd     Goal difference for club B in H2H matches.
- *     @type int $a_goals  Goals scored by club A in H2H matches.
- *     @type int $b_goals  Goals scored by club B in H2H matches.
- * }
- */
-function wpcm_get_h2h_points( $club_a_id, $club_b_id ) {
-	global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_cache;
-
-	if ( ! is_array( $wpcm_h2h_cache ) ) {
+if ( ! function_exists( 'wpcm_h2h_cache_reset' ) ) {
+	/**
+	 * Reset the in-memory H2H results cache.
+	 */
+	function wpcm_h2h_cache_reset() {
+		global $wpcm_h2h_cache;
 		$wpcm_h2h_cache = array();
 	}
-	$cache = &$wpcm_h2h_cache;
+}
 
-	// Return neutral result when H2H context is not set.
-	if ( ! $wpcm_h2h_comp && ! $wpcm_h2h_season ) {
-		return array(
+if ( ! function_exists( 'wpcm_get_h2h_points' ) ) {
+	/**
+	 * Calculate head-to-head record between two clubs in the current H2H context.
+	 *
+	 * Results are cached in-memory for the duration of the request to avoid
+	 * repeated database queries when called from a usort comparator.
+	 *
+	 * Returns points, goal difference, and goals scored for each club
+	 * based only on their direct matches in the given competition and season.
+	 *
+	 * @param int $club_a_id Club A post ID.
+	 * @param int $club_b_id Club B post ID.
+	 * @return array {
+	 *     @type int $a_points Points earned by club A in H2H matches.
+	 *     @type int $b_points Points earned by club B in H2H matches.
+	 *     @type int $a_gd     Goal difference for club A in H2H matches.
+	 *     @type int $b_gd     Goal difference for club B in H2H matches.
+	 *     @type int $a_goals  Goals scored by club A in H2H matches.
+	 *     @type int $b_goals  Goals scored by club B in H2H matches.
+	 * }
+	 */
+	function wpcm_get_h2h_points( $club_a_id, $club_b_id ) {
+		global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_cache;
+
+		if ( ! is_array( $wpcm_h2h_cache ) ) {
+			$wpcm_h2h_cache = array();
+		}
+		$cache = &$wpcm_h2h_cache;
+
+		// Return neutral result when H2H context is not set.
+		if ( ! $wpcm_h2h_comp && ! $wpcm_h2h_season ) {
+			return array(
+				'a_points' => 0,
+				'b_points' => 0,
+				'a_gd'     => 0,
+				'b_gd'     => 0,
+				'a_goals'  => 0,
+				'b_goals'  => 0,
+			);
+		}
+
+		// Normalise cache key so (A,B) and (B,A) share the same entry.
+		$lo  = min( $club_a_id, $club_b_id );
+		$hi  = max( $club_a_id, $club_b_id );
+		$key = "{$wpcm_h2h_comp}_{$wpcm_h2h_season}_{$lo}_{$hi}";
+
+		if ( isset( $cache[ $key ] ) ) {
+			$cached = $cache[ $key ];
+			// If the caller asked with the IDs in the same order, return as-is.
+			if ( $club_a_id === $lo ) {
+				return $cached;
+			}
+			// Swap a/b in the result.
+			return array(
+				'a_points' => $cached['b_points'],
+				'b_points' => $cached['a_points'],
+				'a_gd'     => $cached['b_gd'],
+				'b_gd'     => $cached['a_gd'],
+				'a_goals'  => $cached['b_goals'],
+				'b_goals'  => $cached['a_goals'],
+			);
+		}
+
+		$win_pts  = (int) get_option( 'wpcm_standings_win_points', 3 );
+		$draw_pts = (int) get_option( 'wpcm_standings_draw_points', 1 );
+		$loss_pts = (int) get_option( 'wpcm_standings_loss_points', 0 );
+
+		$result = array(
 			'a_points' => 0,
 			'b_points' => 0,
 			'a_gd'     => 0,
@@ -293,163 +336,131 @@ function wpcm_get_h2h_points( $club_a_id, $club_b_id ) {
 			'a_goals'  => 0,
 			'b_goals'  => 0,
 		);
-	}
 
-	// Normalise cache key so (A,B) and (B,A) share the same entry.
-	$lo  = min( $club_a_id, $club_b_id );
-	$hi  = max( $club_a_id, $club_b_id );
-	$key = "{$wpcm_h2h_comp}_{$wpcm_h2h_season}_{$lo}_{$hi}";
-
-	if ( isset( $cache[ $key ] ) ) {
-		$cached = $cache[ $key ];
-		// If the caller asked with the IDs in the same order, return as-is.
-		if ( $club_a_id === $lo ) {
-			return $cached;
+		$tax_query = array();
+		if ( $wpcm_h2h_comp ) {
+			$tax_query[] = array(
+				'taxonomy' => 'wpcm_comp',
+				'terms'    => $wpcm_h2h_comp,
+				'field'    => 'term_id',
+			);
 		}
-		// Swap a/b in the result.
-		return array(
-			'a_points' => $cached['b_points'],
-			'b_points' => $cached['a_points'],
-			'a_gd'     => $cached['b_gd'],
-			'b_gd'     => $cached['a_gd'],
-			'a_goals'  => $cached['b_goals'],
-			'b_goals'  => $cached['a_goals'],
+		if ( $wpcm_h2h_season ) {
+			$tax_query[] = array(
+				'taxonomy' => 'wpcm_season',
+				'terms'    => $wpcm_h2h_season,
+				'field'    => 'term_id',
+			);
+		}
+
+		// Find matches where club A is home and club B is away.
+		$args = array(
+			'post_type'      => 'wpcm_match',
+			'posts_per_page' => -1,
+			'no_found_rows'  => true,
+			'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				array(
+					'key'   => 'wpcm_home_club',
+					'value' => $club_a_id,
+				),
+				array(
+					'key'   => 'wpcm_away_club',
+					'value' => $club_b_id,
+				),
+			),
+			'tax_query'      => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		);
-	}
 
-	$win_pts  = (int) get_option( 'wpcm_standings_win_points', 3 );
-	$draw_pts = (int) get_option( 'wpcm_standings_draw_points', 1 );
-	$loss_pts = (int) get_option( 'wpcm_standings_loss_points', 0 );
+		$matches = get_posts( $args );
 
-	$result = array(
-		'a_points' => 0,
-		'b_points' => 0,
-		'a_gd'     => 0,
-		'b_gd'     => 0,
-		'a_goals'  => 0,
-		'b_goals'  => 0,
-	);
+		foreach ( $matches as $match ) {
+			$played    = (int) get_post_meta( $match->ID, 'wpcm_played', true );
+			$friendly  = (int) get_post_meta( $match->ID, 'wpcm_friendly', true );
+			$postponed = get_post_meta( $match->ID, '_wpcm_postponed', true );
 
-	$tax_query = array();
-	if ( $wpcm_h2h_comp ) {
-		$tax_query[] = array(
-			'taxonomy' => 'wpcm_comp',
-			'terms'    => $wpcm_h2h_comp,
-			'field'    => 'term_id',
-		);
-	}
-	if ( $wpcm_h2h_season ) {
-		$tax_query[] = array(
-			'taxonomy' => 'wpcm_season',
-			'terms'    => $wpcm_h2h_season,
-			'field'    => 'term_id',
-		);
-	}
+			if ( ! $played || $friendly || $postponed ) {
+				continue;
+			}
 
-	// Find matches where club A is home and club B is away.
-	$args = array(
-		'post_type'      => 'wpcm_match',
-		'posts_per_page' => -1,
-		'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			$home_goals = (int) get_post_meta( $match->ID, 'wpcm_home_goals', true );
+			$away_goals = (int) get_post_meta( $match->ID, 'wpcm_away_goals', true );
+
+			$result['a_goals'] += $home_goals;
+			$result['b_goals'] += $away_goals;
+			$result['a_gd']    += $home_goals - $away_goals;
+			$result['b_gd']    += $away_goals - $home_goals;
+
+			if ( $home_goals > $away_goals ) {
+				$result['a_points'] += $win_pts;
+				$result['b_points'] += $loss_pts;
+			} elseif ( $home_goals < $away_goals ) {
+				$result['a_points'] += $loss_pts;
+				$result['b_points'] += $win_pts;
+			} else {
+				$result['a_points'] += $draw_pts;
+				$result['b_points'] += $draw_pts;
+			}
+		}
+
+		// Find matches where club B is home and club A is away.
+		$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			array(
 				'key'   => 'wpcm_home_club',
-				'value' => $club_a_id,
+				'value' => $club_b_id,
 			),
 			array(
 				'key'   => 'wpcm_away_club',
-				'value' => $club_b_id,
+				'value' => $club_a_id,
 			),
-		),
-		'tax_query'      => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-	);
-
-	$matches = get_posts( $args );
-
-	foreach ( $matches as $match ) {
-		$played   = (int) get_post_meta( $match->ID, 'wpcm_played', true );
-		$friendly = (int) get_post_meta( $match->ID, 'wpcm_friendly', true );
-
-		if ( ! $played || $friendly ) {
-			continue;
-		}
-
-		$home_goals = (int) get_post_meta( $match->ID, 'wpcm_home_goals', true );
-		$away_goals = (int) get_post_meta( $match->ID, 'wpcm_away_goals', true );
-
-		$result['a_goals'] += $home_goals;
-		$result['b_goals'] += $away_goals;
-		$result['a_gd']    += $home_goals - $away_goals;
-		$result['b_gd']    += $away_goals - $home_goals;
-
-		if ( $home_goals > $away_goals ) {
-			$result['a_points'] += $win_pts;
-			$result['b_points'] += $loss_pts;
-		} elseif ( $home_goals < $away_goals ) {
-			$result['a_points'] += $loss_pts;
-			$result['b_points'] += $win_pts;
-		} else {
-			$result['a_points'] += $draw_pts;
-			$result['b_points'] += $draw_pts;
-		}
-	}
-
-	// Find matches where club B is home and club A is away.
-	$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-		array(
-			'key'   => 'wpcm_home_club',
-			'value' => $club_b_id,
-		),
-		array(
-			'key'   => 'wpcm_away_club',
-			'value' => $club_a_id,
-		),
-	);
-
-	$matches = get_posts( $args );
-
-	foreach ( $matches as $match ) {
-		$played   = (int) get_post_meta( $match->ID, 'wpcm_played', true );
-		$friendly = (int) get_post_meta( $match->ID, 'wpcm_friendly', true );
-
-		if ( ! $played || $friendly ) {
-			continue;
-		}
-
-		$home_goals = (int) get_post_meta( $match->ID, 'wpcm_home_goals', true );
-		$away_goals = (int) get_post_meta( $match->ID, 'wpcm_away_goals', true );
-
-		$result['b_goals'] += $home_goals;
-		$result['a_goals'] += $away_goals;
-		$result['b_gd']    += $home_goals - $away_goals;
-		$result['a_gd']    += $away_goals - $home_goals;
-
-		if ( $home_goals > $away_goals ) {
-			$result['b_points'] += $win_pts;
-			$result['a_points'] += $loss_pts;
-		} elseif ( $home_goals < $away_goals ) {
-			$result['b_points'] += $loss_pts;
-			$result['a_points'] += $win_pts;
-		} else {
-			$result['a_points'] += $draw_pts;
-			$result['b_points'] += $draw_pts;
-		}
-	}
-
-	// Store result in cache, keyed with the lower ID first.
-	if ( $club_a_id === $lo ) {
-		$cache[ $key ] = $result;
-	} else {
-		$cache[ $key ] = array(
-			'a_points' => $result['b_points'],
-			'b_points' => $result['a_points'],
-			'a_gd'     => $result['b_gd'],
-			'b_gd'     => $result['a_gd'],
-			'a_goals'  => $result['b_goals'],
-			'b_goals'  => $result['a_goals'],
 		);
-	}
 
-	return $result;
+		$matches = get_posts( $args );
+
+		foreach ( $matches as $match ) {
+			$played    = (int) get_post_meta( $match->ID, 'wpcm_played', true );
+			$friendly  = (int) get_post_meta( $match->ID, 'wpcm_friendly', true );
+			$postponed = get_post_meta( $match->ID, '_wpcm_postponed', true );
+
+			if ( ! $played || $friendly || $postponed ) {
+				continue;
+			}
+
+			$home_goals = (int) get_post_meta( $match->ID, 'wpcm_home_goals', true );
+			$away_goals = (int) get_post_meta( $match->ID, 'wpcm_away_goals', true );
+
+			$result['b_goals'] += $home_goals;
+			$result['a_goals'] += $away_goals;
+			$result['b_gd']    += $home_goals - $away_goals;
+			$result['a_gd']    += $away_goals - $home_goals;
+
+			if ( $home_goals > $away_goals ) {
+				$result['b_points'] += $win_pts;
+				$result['a_points'] += $loss_pts;
+			} elseif ( $home_goals < $away_goals ) {
+				$result['b_points'] += $loss_pts;
+				$result['a_points'] += $win_pts;
+			} else {
+				$result['a_points'] += $draw_pts;
+				$result['b_points'] += $draw_pts;
+			}
+		}
+
+		// Store result in cache, keyed with the lower ID first.
+		if ( $club_a_id === $lo ) {
+			$cache[ $key ] = $result;
+		} else {
+			$cache[ $key ] = array(
+				'a_points' => $result['b_points'],
+				'b_points' => $result['a_points'],
+				'a_gd'     => $result['b_gd'],
+				'b_gd'     => $result['a_gd'],
+				'a_goals'  => $result['b_goals'],
+				'b_goals'  => $result['a_goals'],
+			);
+		}
+
+		return $result;
+	}
 }
 
 if ( ! function_exists( 'wpcm_table_priorities' ) ) {

--- a/includes/wpcm-standings-functions.php
+++ b/includes/wpcm-standings-functions.php
@@ -238,16 +238,28 @@ function wpcm_set_h2h_context( $comp, $season ) {
 }
 
 /**
- * Clear H2H context after sorting is complete.
+ * Clear H2H context and in-memory cache after sorting is complete.
  */
 function wpcm_clear_h2h_context() {
 	global $wpcm_h2h_comp, $wpcm_h2h_season;
 	$wpcm_h2h_comp   = null;
 	$wpcm_h2h_season = null;
+	wpcm_h2h_cache_reset();
+}
+
+/**
+ * Reset the in-memory H2H results cache.
+ */
+function wpcm_h2h_cache_reset() {
+	global $wpcm_h2h_cache;
+	$wpcm_h2h_cache = array();
 }
 
 /**
  * Calculate head-to-head record between two clubs in the current H2H context.
+ *
+ * Results are cached in-memory for the duration of the request to avoid
+ * repeated database queries when called from a usort comparator.
  *
  * Returns points, goal difference, and goals scored for each club
  * based only on their direct matches in the given competition and season.
@@ -264,7 +276,46 @@ function wpcm_clear_h2h_context() {
  * }
  */
 function wpcm_get_h2h_points( $club_a_id, $club_b_id ) {
-	global $wpcm_h2h_comp, $wpcm_h2h_season;
+	global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_cache;
+
+	if ( ! is_array( $wpcm_h2h_cache ) ) {
+		$wpcm_h2h_cache = array();
+	}
+	$cache = &$wpcm_h2h_cache;
+
+	// Return neutral result when H2H context is not set.
+	if ( ! $wpcm_h2h_comp && ! $wpcm_h2h_season ) {
+		return array(
+			'a_points' => 0,
+			'b_points' => 0,
+			'a_gd'     => 0,
+			'b_gd'     => 0,
+			'a_goals'  => 0,
+			'b_goals'  => 0,
+		);
+	}
+
+	// Normalise cache key so (A,B) and (B,A) share the same entry.
+	$lo  = min( $club_a_id, $club_b_id );
+	$hi  = max( $club_a_id, $club_b_id );
+	$key = "{$wpcm_h2h_comp}_{$wpcm_h2h_season}_{$lo}_{$hi}";
+
+	if ( isset( $cache[ $key ] ) ) {
+		$cached = $cache[ $key ];
+		// If the caller asked with the IDs in the same order, return as-is.
+		if ( $club_a_id === $lo ) {
+			return $cached;
+		}
+		// Swap a/b in the result.
+		return array(
+			'a_points' => $cached['b_points'],
+			'b_points' => $cached['a_points'],
+			'a_gd'     => $cached['b_gd'],
+			'b_gd'     => $cached['a_gd'],
+			'a_goals'  => $cached['b_goals'],
+			'b_goals'  => $cached['a_goals'],
+		);
+	}
 
 	$win_pts  = (int) get_option( 'wpcm_standings_win_points', 3 );
 	$draw_pts = (int) get_option( 'wpcm_standings_draw_points', 1 );
@@ -384,6 +435,20 @@ function wpcm_get_h2h_points( $club_a_id, $club_b_id ) {
 		}
 	}
 
+	// Store result in cache, keyed with the lower ID first.
+	if ( $club_a_id === $lo ) {
+		$cache[ $key ] = $result;
+	} else {
+		$cache[ $key ] = array(
+			'a_points' => $result['b_points'],
+			'b_points' => $result['a_points'],
+			'a_gd'     => $result['b_gd'],
+			'b_gd'     => $result['a_gd'],
+			'a_goals'  => $result['b_goals'],
+			'b_goals'  => $result['a_goals'],
+		);
+	}
+
 	return $result;
 }
 
@@ -413,8 +478,8 @@ if ( ! function_exists( 'wpcm_table_priorities' ) ) {
 
 if ( ! function_exists( 'wpcm_sort_table_clubs' ) ) {
 	/**
-	 * @param array $a
-	 * @param array $b
+	 * @param object $a
+	 * @param object $b
 	 *
 	 * @return int
 	 */

--- a/includes/wpcm-standings-functions.php
+++ b/includes/wpcm-standings-functions.php
@@ -225,6 +225,168 @@ if ( ! function_exists( 'get_wpcm_table_total_stats' ) ) {
 	}
 }
 
+/**
+ * Store competition and season context for head-to-head lookups during sorting.
+ *
+ * @param int $comp   Competition term ID.
+ * @param int $season Season term ID.
+ */
+function wpcm_set_h2h_context( $comp, $season ) {
+	global $wpcm_h2h_comp, $wpcm_h2h_season;
+	$wpcm_h2h_comp   = $comp;
+	$wpcm_h2h_season = $season;
+}
+
+/**
+ * Clear H2H context after sorting is complete.
+ */
+function wpcm_clear_h2h_context() {
+	global $wpcm_h2h_comp, $wpcm_h2h_season;
+	$wpcm_h2h_comp   = null;
+	$wpcm_h2h_season = null;
+}
+
+/**
+ * Calculate head-to-head record between two clubs in the current H2H context.
+ *
+ * Returns points, goal difference, and goals scored for each club
+ * based only on their direct matches in the given competition and season.
+ *
+ * @param int $club_a_id Club A post ID.
+ * @param int $club_b_id Club B post ID.
+ * @return array {
+ *     @type int $a_points Points earned by club A in H2H matches.
+ *     @type int $b_points Points earned by club B in H2H matches.
+ *     @type int $a_gd     Goal difference for club A in H2H matches.
+ *     @type int $b_gd     Goal difference for club B in H2H matches.
+ *     @type int $a_goals  Goals scored by club A in H2H matches.
+ *     @type int $b_goals  Goals scored by club B in H2H matches.
+ * }
+ */
+function wpcm_get_h2h_points( $club_a_id, $club_b_id ) {
+	global $wpcm_h2h_comp, $wpcm_h2h_season;
+
+	$win_pts  = (int) get_option( 'wpcm_standings_win_points', 3 );
+	$draw_pts = (int) get_option( 'wpcm_standings_draw_points', 1 );
+	$loss_pts = (int) get_option( 'wpcm_standings_loss_points', 0 );
+
+	$result = array(
+		'a_points' => 0,
+		'b_points' => 0,
+		'a_gd'     => 0,
+		'b_gd'     => 0,
+		'a_goals'  => 0,
+		'b_goals'  => 0,
+	);
+
+	$tax_query = array();
+	if ( $wpcm_h2h_comp ) {
+		$tax_query[] = array(
+			'taxonomy' => 'wpcm_comp',
+			'terms'    => $wpcm_h2h_comp,
+			'field'    => 'term_id',
+		);
+	}
+	if ( $wpcm_h2h_season ) {
+		$tax_query[] = array(
+			'taxonomy' => 'wpcm_season',
+			'terms'    => $wpcm_h2h_season,
+			'field'    => 'term_id',
+		);
+	}
+
+	// Find matches where club A is home and club B is away.
+	$args = array(
+		'post_type'      => 'wpcm_match',
+		'posts_per_page' => -1,
+		'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			array(
+				'key'   => 'wpcm_home_club',
+				'value' => $club_a_id,
+			),
+			array(
+				'key'   => 'wpcm_away_club',
+				'value' => $club_b_id,
+			),
+		),
+		'tax_query'      => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+	);
+
+	$matches = get_posts( $args );
+
+	foreach ( $matches as $match ) {
+		$played   = (int) get_post_meta( $match->ID, 'wpcm_played', true );
+		$friendly = (int) get_post_meta( $match->ID, 'wpcm_friendly', true );
+
+		if ( ! $played || $friendly ) {
+			continue;
+		}
+
+		$home_goals = (int) get_post_meta( $match->ID, 'wpcm_home_goals', true );
+		$away_goals = (int) get_post_meta( $match->ID, 'wpcm_away_goals', true );
+
+		$result['a_goals'] += $home_goals;
+		$result['b_goals'] += $away_goals;
+		$result['a_gd']    += $home_goals - $away_goals;
+		$result['b_gd']    += $away_goals - $home_goals;
+
+		if ( $home_goals > $away_goals ) {
+			$result['a_points'] += $win_pts;
+			$result['b_points'] += $loss_pts;
+		} elseif ( $home_goals < $away_goals ) {
+			$result['a_points'] += $loss_pts;
+			$result['b_points'] += $win_pts;
+		} else {
+			$result['a_points'] += $draw_pts;
+			$result['b_points'] += $draw_pts;
+		}
+	}
+
+	// Find matches where club B is home and club A is away.
+	$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		array(
+			'key'   => 'wpcm_home_club',
+			'value' => $club_b_id,
+		),
+		array(
+			'key'   => 'wpcm_away_club',
+			'value' => $club_a_id,
+		),
+	);
+
+	$matches = get_posts( $args );
+
+	foreach ( $matches as $match ) {
+		$played   = (int) get_post_meta( $match->ID, 'wpcm_played', true );
+		$friendly = (int) get_post_meta( $match->ID, 'wpcm_friendly', true );
+
+		if ( ! $played || $friendly ) {
+			continue;
+		}
+
+		$home_goals = (int) get_post_meta( $match->ID, 'wpcm_home_goals', true );
+		$away_goals = (int) get_post_meta( $match->ID, 'wpcm_away_goals', true );
+
+		$result['b_goals'] += $home_goals;
+		$result['a_goals'] += $away_goals;
+		$result['b_gd']    += $home_goals - $away_goals;
+		$result['a_gd']    += $away_goals - $home_goals;
+
+		if ( $home_goals > $away_goals ) {
+			$result['b_points'] += $win_pts;
+			$result['a_points'] += $loss_pts;
+		} elseif ( $home_goals < $away_goals ) {
+			$result['b_points'] += $loss_pts;
+			$result['a_points'] += $win_pts;
+		} else {
+			$result['a_points'] += $draw_pts;
+			$result['b_points'] += $draw_pts;
+		}
+	}
+
+	return $result;
+}
+
 if ( ! function_exists( 'wpcm_table_priorities' ) ) {
 	/**
 	 * @return array
@@ -263,6 +425,41 @@ if ( ! function_exists( 'wpcm_sort_table_clubs' ) ) {
 		// Loop through priorities
 		foreach ( $priorities as $priority ) {
 
+			if ( 'h2h' === $priority['column'] ) {
+				// Head-to-head tiebreaker: compare direct match record.
+				$h2h = wpcm_get_h2h_points( $a->ID, $b->ID );
+
+				// Compare H2H points first.
+				if ( $h2h['a_points'] !== $h2h['b_points'] ) {
+					$output = $h2h['a_points'] - $h2h['b_points'];
+					if ( 'DESC' === $priority['order'] ) {
+						$output = 0 - $output;
+					}
+					return ( $output > 0 ? 1 : -1 );
+				}
+
+				// If H2H points tied, compare H2H goal difference.
+				if ( $h2h['a_gd'] !== $h2h['b_gd'] ) {
+					$output = $h2h['a_gd'] - $h2h['b_gd'];
+					if ( 'DESC' === $priority['order'] ) {
+						$output = 0 - $output;
+					}
+					return ( $output > 0 ? 1 : -1 );
+				}
+
+				// If H2H GD tied, compare H2H goals scored.
+				if ( $h2h['a_goals'] !== $h2h['b_goals'] ) {
+					$output = $h2h['a_goals'] - $h2h['b_goals'];
+					if ( 'DESC' === $priority['order'] ) {
+						$output = 0 - $output;
+					}
+					return ( $output > 0 ? 1 : -1 );
+				}
+
+				// H2H completely tied, fall through to next priority.
+				continue;
+			}
+
 			if ( wpcm_array_value( $a->wpcm_stats, $priority['column'], 0 ) !== wpcm_array_value( $b->wpcm_stats, $priority['column'], 0 ) ) {
 
 				// Compare column values
@@ -279,7 +476,6 @@ if ( ! function_exists( 'wpcm_sort_table_clubs' ) ) {
 		}
 
 		// Default sort by alphabetical
-		// return strcmp( wpcm_array_value( $a, 'name', '' ), wpcm_array_value( $b, 'name', '' ) );
 		return strcmp( $a->post_name, $b->post_name );
 	}
 }

--- a/includes/wpcm-standings-functions.php
+++ b/includes/wpcm-standings-functions.php
@@ -35,38 +35,20 @@ if ( ! function_exists( 'wpcm_club_standings_sort' ) ) {
 		$priority_2 = get_option( 'wpcm_standings_orderby_2' );
 		$priority_3 = get_option( 'wpcm_standings_orderby_3' );
 
-		if ( $a->wpcm_stats[ $priority_1 ] > $b->wpcm_stats[ $priority_1 ] ) {
-
-			return -1;
-
-		} elseif ( $a->wpcm_stats[ $priority_1 ] < $b->wpcm_stats[ $priority_1 ] ) {
-
-			return 1;
-
-		} elseif ( $a->wpcm_stats[ $priority_2 ] > $b->wpcm_stats[ $priority_2 ] ) {
-
+		$priorities = array( $priority_1, $priority_2, $priority_3 );
+		foreach ( $priorities as $col ) {
+			// Skip H2H — not supported in the legacy standings shortcode sorter.
+			if ( 'h2h' === $col || ! isset( $a->wpcm_stats[ $col ], $b->wpcm_stats[ $col ] ) ) {
+				continue;
+			}
+			if ( $a->wpcm_stats[ $col ] > $b->wpcm_stats[ $col ] ) {
 				return -1;
-
-		} elseif ( $a->wpcm_stats[ $priority_2 ] < $b->wpcm_stats[ $priority_2 ] ) {
-
-			return 1;
-
-		} elseif ( $a->wpcm_stats[ $priority_3 ] > $b->wpcm_stats[ $priority_3 ] ) {
-
-				return -1;
-
-		} elseif ( $a->wpcm_stats[ $priority_3 ] < $b->wpcm_stats[ $priority_3 ] ) {
-
-			return 1;
-
-		} elseif ( strcmp( $a->post_title, $b->post_title ) < 0 ) {
-
-				return -1;
-
-		} else {
-
-			return 1;
+			} elseif ( $a->wpcm_stats[ $col ] < $b->wpcm_stats[ $col ] ) {
+				return 1;
+			}
 		}
+
+		return strcmp( $a->post_title, $b->post_title );
 	}
 }
 
@@ -229,13 +211,14 @@ if ( ! function_exists( 'wpcm_set_h2h_context' ) ) {
 	/**
 	 * Store competition and season context for head-to-head lookups during sorting.
 	 *
-	 * @param int $comp   Competition term ID.
-	 * @param int $season Season term ID.
+	 * @param int|null $comp   Competition term ID (null = no restriction).
+	 * @param int|null $season Season term ID (null = no restriction).
 	 */
 	function wpcm_set_h2h_context( $comp, $season ) {
-		global $wpcm_h2h_comp, $wpcm_h2h_season;
-		$wpcm_h2h_comp   = $comp;
-		$wpcm_h2h_season = $season;
+		global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_context_set;
+		$wpcm_h2h_comp        = $comp;
+		$wpcm_h2h_season      = $season;
+		$wpcm_h2h_context_set = true;
 	}
 }
 
@@ -244,9 +227,10 @@ if ( ! function_exists( 'wpcm_clear_h2h_context' ) ) {
 	 * Clear H2H context and in-memory cache after sorting is complete.
 	 */
 	function wpcm_clear_h2h_context() {
-		global $wpcm_h2h_comp, $wpcm_h2h_season;
-		$wpcm_h2h_comp   = null;
-		$wpcm_h2h_season = null;
+		global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_context_set;
+		$wpcm_h2h_comp        = null;
+		$wpcm_h2h_season      = null;
+		$wpcm_h2h_context_set = false;
 		wpcm_h2h_cache_reset();
 	}
 }
@@ -283,37 +267,39 @@ if ( ! function_exists( 'wpcm_get_h2h_points' ) ) {
 	 * }
 	 */
 	function wpcm_get_h2h_points( $club_a_id, $club_b_id ) {
-		global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_cache;
+		global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_cache, $wpcm_h2h_context_set;
+
+		$neutral = array(
+			'a_points' => 0,
+			'b_points' => 0,
+			'a_gd'     => 0,
+			'b_gd'     => 0,
+			'a_goals'  => 0,
+			'b_goals'  => 0,
+		);
 
 		if ( ! is_array( $wpcm_h2h_cache ) ) {
 			$wpcm_h2h_cache = array();
 		}
 		$cache = &$wpcm_h2h_cache;
 
-		// Return neutral result when H2H context is not set.
-		if ( ! $wpcm_h2h_comp && ! $wpcm_h2h_season ) {
-			return array(
-				'a_points' => 0,
-				'b_points' => 0,
-				'a_gd'     => 0,
-				'b_gd'     => 0,
-				'a_goals'  => 0,
-				'b_goals'  => 0,
-			);
+		// Return neutral result when H2H context was never set by a caller.
+		if ( empty( $wpcm_h2h_context_set ) ) {
+			return $neutral;
 		}
 
 		// Normalise cache key so (A,B) and (B,A) share the same entry.
-		$lo  = min( $club_a_id, $club_b_id );
-		$hi  = max( $club_a_id, $club_b_id );
-		$key = "{$wpcm_h2h_comp}_{$wpcm_h2h_season}_{$lo}_{$hi}";
+		$lo       = min( $club_a_id, $club_b_id );
+		$hi       = max( $club_a_id, $club_b_id );
+		$comp_key = $wpcm_h2h_comp ? $wpcm_h2h_comp : '0';
+		$ssn_key  = $wpcm_h2h_season ? $wpcm_h2h_season : '0';
+		$key      = "{$comp_key}_{$ssn_key}_{$lo}_{$hi}";
 
 		if ( isset( $cache[ $key ] ) ) {
 			$cached = $cache[ $key ];
-			// If the caller asked with the IDs in the same order, return as-is.
 			if ( $club_a_id === $lo ) {
 				return $cached;
 			}
-			// Swap a/b in the result.
 			return array(
 				'a_points' => $cached['b_points'],
 				'b_points' => $cached['a_points'],
@@ -324,18 +310,14 @@ if ( ! function_exists( 'wpcm_get_h2h_points' ) ) {
 			);
 		}
 
+		$sport    = get_option( 'wpcm_sport' );
 		$win_pts  = (int) get_option( 'wpcm_standings_win_points', 3 );
 		$draw_pts = (int) get_option( 'wpcm_standings_draw_points', 1 );
 		$loss_pts = (int) get_option( 'wpcm_standings_loss_points', 0 );
+		$otw_pts  = (int) get_option( 'wpcm_standings_otw_points', 0 );
+		$otl_pts  = (int) get_option( 'wpcm_standings_otl_points', 1 );
 
-		$result = array(
-			'a_points' => 0,
-			'b_points' => 0,
-			'a_gd'     => 0,
-			'b_gd'     => 0,
-			'a_goals'  => 0,
-			'b_goals'  => 0,
-		);
+		$result = $neutral;
 
 		$tax_query = array();
 		if ( $wpcm_h2h_comp ) {
@@ -353,92 +335,115 @@ if ( ! function_exists( 'wpcm_get_h2h_points' ) ) {
 			);
 		}
 
-		// Find matches where club A is home and club B is away.
+		// Query both directions (A home / B away, and B home / A away) using OR.
 		$args = array(
-			'post_type'      => 'wpcm_match',
-			'posts_per_page' => -1,
-			'no_found_rows'  => true,
-			'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'post_type'              => 'wpcm_match',
+			'posts_per_page'         => -1,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'suppress_filters'       => true,
+			'meta_query'             => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'relation' => 'OR',
 				array(
-					'key'   => 'wpcm_home_club',
-					'value' => $club_a_id,
+					'relation' => 'AND',
+					array(
+						'key'   => 'wpcm_home_club',
+						'value' => $club_a_id,
+					),
+					array(
+						'key'   => 'wpcm_away_club',
+						'value' => $club_b_id,
+					),
 				),
 				array(
-					'key'   => 'wpcm_away_club',
-					'value' => $club_b_id,
+					'relation' => 'AND',
+					array(
+						'key'   => 'wpcm_home_club',
+						'value' => $club_b_id,
+					),
+					array(
+						'key'   => 'wpcm_away_club',
+						'value' => $club_a_id,
+					),
 				),
 			),
-			'tax_query'      => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			'tax_query'              => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		);
 
-		$matches = get_posts( $args );
+		$match_ids = get_posts( $args );
 
-		foreach ( $matches as $match ) {
-			$played    = (int) get_post_meta( $match->ID, 'wpcm_played', true );
-			$friendly  = (int) get_post_meta( $match->ID, 'wpcm_friendly', true );
-			$postponed = get_post_meta( $match->ID, '_wpcm_postponed', true );
+		foreach ( $match_ids as $match_id ) {
+			$played    = (int) get_post_meta( $match_id, 'wpcm_played', true );
+			$friendly  = (int) get_post_meta( $match_id, 'wpcm_friendly', true );
+			$postponed = (int) get_post_meta( $match_id, '_wpcm_postponed', true );
+			$walkover  = get_post_meta( $match_id, '_wpcm_walkover', true );
+			$overtime  = (int) get_post_meta( $match_id, 'wpcm_overtime', true );
 
-			if ( ! $played || $friendly || $postponed ) {
+			$home_id = (int) get_post_meta( $match_id, 'wpcm_home_club', true );
+			// Determine which club is "a" and which is "b" in this match.
+			$a_is_home = ( $home_id === $club_a_id );
+
+			// Handle walkover outcomes for postponed matches.
+			if ( $postponed ) {
+				if ( 'home_win' === $walkover ) {
+					if ( $a_is_home ) {
+						$result['a_points'] += $win_pts;
+						$result['b_points'] += $loss_pts;
+					} else {
+						$result['b_points'] += $win_pts;
+						$result['a_points'] += $loss_pts;
+					}
+				} elseif ( 'away_win' === $walkover ) {
+					if ( $a_is_home ) {
+						$result['a_points'] += $loss_pts;
+						$result['b_points'] += $win_pts;
+					} else {
+						$result['b_points'] += $loss_pts;
+						$result['a_points'] += $win_pts;
+					}
+				}
 				continue;
 			}
 
-			$home_goals = (int) get_post_meta( $match->ID, 'wpcm_home_goals', true );
-			$away_goals = (int) get_post_meta( $match->ID, 'wpcm_away_goals', true );
+			if ( ! $played || $friendly ) {
+				continue;
+			}
 
-			$result['a_goals'] += $home_goals;
-			$result['b_goals'] += $away_goals;
-			$result['a_gd']    += $home_goals - $away_goals;
-			$result['b_gd']    += $away_goals - $home_goals;
+			$home_goals = (int) get_post_meta( $match_id, 'wpcm_home_goals', true );
+			$away_goals = (int) get_post_meta( $match_id, 'wpcm_away_goals', true );
 
-			if ( $home_goals > $away_goals ) {
-				$result['a_points'] += $win_pts;
-				$result['b_points'] += $loss_pts;
-			} elseif ( $home_goals < $away_goals ) {
-				$result['a_points'] += $loss_pts;
-				$result['b_points'] += $win_pts;
+			if ( $a_is_home ) {
+				$a_goals = $home_goals;
+				$b_goals = $away_goals;
 			} else {
-				$result['a_points'] += $draw_pts;
-				$result['b_points'] += $draw_pts;
-			}
-		}
-
-		// Find matches where club B is home and club A is away.
-		$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			array(
-				'key'   => 'wpcm_home_club',
-				'value' => $club_b_id,
-			),
-			array(
-				'key'   => 'wpcm_away_club',
-				'value' => $club_a_id,
-			),
-		);
-
-		$matches = get_posts( $args );
-
-		foreach ( $matches as $match ) {
-			$played    = (int) get_post_meta( $match->ID, 'wpcm_played', true );
-			$friendly  = (int) get_post_meta( $match->ID, 'wpcm_friendly', true );
-			$postponed = get_post_meta( $match->ID, '_wpcm_postponed', true );
-
-			if ( ! $played || $friendly || $postponed ) {
-				continue;
+				$a_goals = $away_goals;
+				$b_goals = $home_goals;
 			}
 
-			$home_goals = (int) get_post_meta( $match->ID, 'wpcm_home_goals', true );
-			$away_goals = (int) get_post_meta( $match->ID, 'wpcm_away_goals', true );
+			$result['a_goals'] += $a_goals;
+			$result['b_goals'] += $b_goals;
+			$result['a_gd']    += $a_goals - $b_goals;
+			$result['b_gd']    += $b_goals - $a_goals;
 
-			$result['b_goals'] += $home_goals;
-			$result['a_goals'] += $away_goals;
-			$result['b_gd']    += $home_goals - $away_goals;
-			$result['a_gd']    += $away_goals - $home_goals;
-
-			if ( $home_goals > $away_goals ) {
-				$result['b_points'] += $win_pts;
-				$result['a_points'] += $loss_pts;
-			} elseif ( $home_goals < $away_goals ) {
-				$result['b_points'] += $loss_pts;
-				$result['a_points'] += $win_pts;
+			// Use overtime-aware points for hockey/basketball.
+			if ( $a_goals > $b_goals ) {
+				if ( $overtime && in_array( $sport, array( 'hockey', 'basketball' ), true ) ) {
+					$result['a_points'] += $otw_pts;
+					$result['b_points'] += $otl_pts;
+				} else {
+					$result['a_points'] += $win_pts;
+					$result['b_points'] += $loss_pts;
+				}
+			} elseif ( $a_goals < $b_goals ) {
+				if ( $overtime && in_array( $sport, array( 'hockey', 'basketball' ), true ) ) {
+					$result['a_points'] += $otl_pts;
+					$result['b_points'] += $otw_pts;
+				} else {
+					$result['a_points'] += $loss_pts;
+					$result['b_points'] += $win_pts;
+				}
 			} else {
 				$result['a_points'] += $draw_pts;
 				$result['b_points'] += $draw_pts;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,11 +91,6 @@ parameters:
 			path: includes/admin/class-wpcm-admin-dashboard.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(WP_Post, WP_Post\\)\\: int, 'wpcm_sort_table…' given\\.$#"
-			count: 2
-			path: includes/admin/class-wpcm-admin-dashboard.php
-
-		-
 			message: "#^Parameter \\#6 \\$callback of function add_submenu_page expects ''\\|\\(callable\\(\\)\\: mixed\\), false given\\.$#"
 			count: 5
 			path: includes/admin/class-wpcm-admin-menus.php
@@ -567,11 +562,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$text of function esc_html expects string, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-table-stats.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(WP_Post, WP_Post\\)\\: int, 'wpcm_sort_table…' given\\.$#"
 			count: 1
 			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-table-stats.php
 
@@ -1351,11 +1341,6 @@ parameters:
 			path: includes/shortcodes/class-wpcm-shortcode-league-table.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(WP_Post, WP_Post\\)\\: int, 'wpcm_sort_table…' given\\.$#"
-			count: 1
-			path: includes/shortcodes/class-wpcm-shortcode-league-table.php
-
-		-
 			message: "#^Variable \\$transient_name might not be defined\\.$#"
 			count: 2
 			path: includes/shortcodes/class-wpcm-shortcode-league-table.php
@@ -1694,16 +1679,6 @@ parameters:
 			message: "#^Variable \\$season might not be defined\\.$#"
 			count: 1
 			path: includes/wpcm-player-functions.php
-
-		-
-			message: "#^Cannot access property \\$post_name on array\\.$#"
-			count: 2
-			path: includes/wpcm-standings-functions.php
-
-		-
-			message: "#^Cannot access property \\$wpcm_stats on array\\.$#"
-			count: 4
-			path: includes/wpcm-standings-functions.php
 
 		-
 			message: "#^Comparison operation \"\\>\" between \\(array\\|float\\|int\\) and 0 results in an error\\.$#"

--- a/tests/wpunit/HeadToHeadSortTest.php
+++ b/tests/wpunit/HeadToHeadSortTest.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Tests for head-to-head tiebreaker sorting in league tables.
+ *
+ * Verifies that when two clubs are tied on points and goal difference,
+ * the head-to-head record between them is used as a tiebreaker when
+ * the H2H sorting option is enabled.
+ */
+
+class HeadToHeadSortTest extends WPCMTestCase {
+
+	/** @var int */
+	private $club_a;
+
+	/** @var int */
+	private $club_b;
+
+	/** @var int */
+	private $club_c;
+
+	/** @var int */
+	private $comp_id;
+
+	/** @var int */
+	private $season_id;
+
+	/** @var array Match IDs for cleanup. */
+	private $match_ids = array();
+
+	public function _setUp() {
+		parent::_setUp();
+
+		update_option( 'wpcm_sport', 'soccer' );
+		update_option( 'wpcm_standings_win_points', 3 );
+		update_option( 'wpcm_standings_draw_points', 1 );
+		update_option( 'wpcm_standings_loss_points', 0 );
+
+		$this->club_a = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'H2H Club A',
+			'post_name'   => 'h2h-club-a',
+			'post_status' => 'publish',
+		) );
+
+		$this->club_b = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'H2H Club B',
+			'post_name'   => 'h2h-club-b',
+			'post_status' => 'publish',
+		) );
+
+		$this->club_c = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'H2H Club C',
+			'post_name'   => 'h2h-club-c',
+			'post_status' => 'publish',
+		) );
+
+		$comp = wp_insert_term( 'H2H Test League', 'wpcm_comp' );
+		$this->comp_id = is_wp_error( $comp ) ? $comp->get_error_data() : $comp['term_id'];
+
+		$season = wp_insert_term( 'H2H Season', 'wpcm_season' );
+		$this->season_id = is_wp_error( $season ) ? $season->get_error_data() : $season['term_id'];
+
+		foreach ( array( $this->club_a, $this->club_b, $this->club_c ) as $club_id ) {
+			wp_set_object_terms( $club_id, $this->comp_id, 'wpcm_comp' );
+			wp_set_object_terms( $club_id, $this->season_id, 'wpcm_season' );
+		}
+	}
+
+	public function _tearDown() {
+		foreach ( $this->match_ids as $id ) {
+			wp_delete_post( $id, true );
+		}
+		wp_delete_post( $this->club_a, true );
+		wp_delete_post( $this->club_b, true );
+		wp_delete_post( $this->club_c, true );
+
+		wpcm_clear_h2h_context();
+
+		parent::_tearDown();
+	}
+
+	/**
+	 * Helper: create a played match with a result.
+	 */
+	private function create_match( $home_id, $away_id, $home_goals, $away_goals ) {
+		$match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'H2H Match',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $match_id, 'wpcm_home_club', $home_id );
+		update_post_meta( $match_id, 'wpcm_away_club', $away_id );
+		update_post_meta( $match_id, 'wpcm_home_goals', $home_goals );
+		update_post_meta( $match_id, 'wpcm_away_goals', $away_goals );
+		update_post_meta( $match_id, 'wpcm_played', '1' );
+
+		wp_set_object_terms( $match_id, $this->comp_id, 'wpcm_comp' );
+		wp_set_object_terms( $match_id, $this->season_id, 'wpcm_season' );
+
+		$this->match_ids[] = $match_id;
+
+		return $match_id;
+	}
+
+	/**
+	 * Build club objects with stats for sorting, same as the shortcode does.
+	 */
+	private function build_clubs_for_sort() {
+		$club_ids = array( $this->club_a, $this->club_b, $this->club_c );
+		$clubs    = array();
+
+		foreach ( $club_ids as $club_id ) {
+			$club             = get_post( $club_id );
+			$club->wpcm_stats = get_wpcm_club_auto_stats( $club_id, $this->comp_id, $this->season_id );
+			$clubs[]          = $club;
+		}
+
+		return $clubs;
+	}
+
+	// -----------------------------------------------------------------------
+	// H2H points calculation
+	// -----------------------------------------------------------------------
+
+	public function test_h2h_points_returns_correct_values_for_winner() {
+		// Club A beats Club B 2-1.
+		$this->create_match( $this->club_a, $this->club_b, 2, 1 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 3, $result['a_points'] );
+		$this->assertEquals( 0, $result['b_points'] );
+	}
+
+	public function test_h2h_points_returns_correct_values_for_draw() {
+		// Club A draws with Club B 1-1.
+		$this->create_match( $this->club_a, $this->club_b, 1, 1 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 1, $result['a_points'] );
+		$this->assertEquals( 1, $result['b_points'] );
+	}
+
+	public function test_h2h_points_accumulates_over_multiple_matches() {
+		// Club A beats Club B 2-0 at home.
+		$this->create_match( $this->club_a, $this->club_b, 2, 0 );
+		// Club B beats Club A 3-1 at home.
+		$this->create_match( $this->club_b, $this->club_a, 3, 1 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		// Club A: 1 win (3pts) + 1 loss (0pts) = 3
+		// Club B: 1 loss (0pts) + 1 win (3pts) = 3
+		$this->assertEquals( 3, $result['a_points'] );
+		$this->assertEquals( 3, $result['b_points'] );
+	}
+
+	public function test_h2h_goal_difference() {
+		// Club A beats Club B 2-0 at home.
+		$this->create_match( $this->club_a, $this->club_b, 2, 0 );
+		// Club B beats Club A 1-0 at home.
+		$this->create_match( $this->club_b, $this->club_a, 1, 0 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		// Club A: scored 2+0=2, conceded 0+1=1 => GD = +1
+		// Club B: scored 0+1=1, conceded 2+0=2 => GD = -1
+		$this->assertEquals( 1, $result['a_gd'] );
+		$this->assertEquals( -1, $result['b_gd'] );
+	}
+
+	// -----------------------------------------------------------------------
+	// Sorting with H2H tiebreaker
+	// -----------------------------------------------------------------------
+
+	public function test_h2h_tiebreaker_ranks_winner_higher() {
+		// Set up: A and B have identical records vs C but A beat B directly.
+		// A beats C 2-0, B beats C 2-0, A beats B 1-0.
+		$this->create_match( $this->club_a, $this->club_c, 2, 0 );
+		$this->create_match( $this->club_b, $this->club_c, 2, 0 );
+		$this->create_match( $this->club_a, $this->club_b, 1, 0 );
+
+		// A: 2W 0D 0L, 6pts, F=3 A=0 GD=+3
+		// B: 1W 0D 1L, 3pts, F=2 A=1 GD=+1
+		// C: 0W 0D 2L, 0pts, F=0 A=4 GD=-4
+		// A is clearly ahead, but let's test with matching points.
+
+		// Better scenario: both tied on points, GD, goals.
+		// A beats B 1-0, B beats C 2-0, C beats A 1-0.
+		// Each has: 1W 0D 1L = 3pts, GD=+0 ... let's check:
+		// A: F=1+0=1, A=0+1=1, GD=0
+		// B: F=0+2=2, A=1+0=1, GD=+1
+		// Not equal GD. Let me design it more carefully.
+
+		// Reset - recreate with precise scenario.
+		foreach ( $this->match_ids as $id ) {
+			wp_delete_post( $id, true );
+		}
+		$this->match_ids = array();
+
+		// A beats B 1-0, B beats A 0-1 ... that means 2 matches between A and B.
+		// Let me use a triangular scenario where all 3 have same pts and GD:
+		// A beats B 1-0
+		// B beats C 1-0
+		// C beats A 1-0
+		// Each team: 1W 0D 1L, 3pts, F=1, A=1, GD=0
+		$this->create_match( $this->club_a, $this->club_b, 1, 0 );
+		$this->create_match( $this->club_b, $this->club_c, 1, 0 );
+		$this->create_match( $this->club_c, $this->club_a, 1, 0 );
+
+		// Configure sorting: pts first, then H2H.
+		update_option( 'wpcm_standings_orderby', 'pts' );
+		update_option( 'wpcm_standings_priority_order', 'DESC' );
+		update_option( 'wpcm_standings_orderby_2', 'h2h' );
+		update_option( 'wpcm_standings_priority_order_2', 'DESC' );
+		update_option( 'wpcm_standings_orderby_3', 'f' );
+		update_option( 'wpcm_standings_priority_order_3', 'DESC' );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$clubs = $this->build_clubs_for_sort();
+		usort( $clubs, 'wpcm_sort_table_clubs' );
+
+		// All three have 3pts, 0 GD, same F. H2H between adjacent pairs:
+		// The sort compares pairs. When comparing A vs B: A beat B, so A > B.
+		// When comparing A vs C: C beat A, so C > A.
+		// When comparing B vs C: B beat C, so B > C.
+		// Expected order: C, A, B (C beat A, A beat B, B beat C — circular, but
+		// usort compares pairs so: C > A > B).
+		$this->assertEquals( $this->club_c, $clubs[0]->ID );
+		$this->assertEquals( $this->club_a, $clubs[1]->ID );
+		$this->assertEquals( $this->club_b, $clubs[2]->ID );
+	}
+
+	public function test_h2h_falls_through_to_next_priority_when_tied() {
+		// A and B draw 0-0 in their only H2H match.
+		// A also beats C 3-0, B also beats C 1-0.
+		// Both have same pts (6) but A has more goals.
+		$this->create_match( $this->club_a, $this->club_b, 0, 0 );
+		$this->create_match( $this->club_a, $this->club_c, 3, 0 );
+		$this->create_match( $this->club_b, $this->club_c, 1, 0 );
+
+		// A: 1W 1D 0L = 4pts, F=3 A=0 GD=+3
+		// B: 1W 1D 0L = 4pts, F=1 A=0 GD=+1
+		// C: 0W 0D 2L = 0pts
+
+		update_option( 'wpcm_standings_orderby', 'pts' );
+		update_option( 'wpcm_standings_priority_order', 'DESC' );
+		update_option( 'wpcm_standings_orderby_2', 'h2h' );
+		update_option( 'wpcm_standings_priority_order_2', 'DESC' );
+		update_option( 'wpcm_standings_orderby_3', 'gd' );
+		update_option( 'wpcm_standings_priority_order_3', 'DESC' );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$clubs = $this->build_clubs_for_sort();
+		usort( $clubs, 'wpcm_sort_table_clubs' );
+
+		// A and B tied on pts (4). H2H: drew 0-0, both 1pt, GD=0. Tied on H2H.
+		// Falls through to priority 3 (GD): A has +3, B has +1. A ranks higher.
+		$this->assertEquals( $this->club_a, $clubs[0]->ID );
+		$this->assertEquals( $this->club_b, $clubs[1]->ID );
+		$this->assertEquals( $this->club_c, $clubs[2]->ID );
+	}
+
+	public function test_h2h_excludes_friendly_matches() {
+		// Friendly: A beats B 5-0 (should be ignored).
+		$friendly = $this->create_match( $this->club_a, $this->club_b, 5, 0 );
+		update_post_meta( $friendly, 'wpcm_friendly', '1' );
+
+		// Competitive: B beats A 1-0.
+		$this->create_match( $this->club_b, $this->club_a, 1, 0 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		// Only the competitive match counts: B won, A lost.
+		$this->assertEquals( 0, $result['a_points'] );
+		$this->assertEquals( 3, $result['b_points'] );
+	}
+
+	public function test_h2h_with_no_direct_matches_returns_zero() {
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 0, $result['a_points'] );
+		$this->assertEquals( 0, $result['b_points'] );
+		$this->assertEquals( 0, $result['a_gd'] );
+		$this->assertEquals( 0, $result['b_gd'] );
+	}
+}

--- a/tests/wpunit/HeadToHeadSortTest.php
+++ b/tests/wpunit/HeadToHeadSortTest.php
@@ -186,13 +186,13 @@ class HeadToHeadSortTest extends WPCMTestCase {
 	// -----------------------------------------------------------------------
 
 	public function test_h2h_tiebreaker_ranks_winner_higher() {
-		// A beats B 1-0, C beats A 2-0, B beats C 2-0.
-		// A: 1W 1L = 3pts, F=1 A=2 GD=-1
-		// B: 1W 1L = 3pts, F=2 A=1 GD=+1
-		// C: 1W 1L = 3pts, F=2 A=2 GD=0
-		// All tied on pts. H2H (priority 2) breaks A vs B: A beat B 1-0.
+		// A and B both beat C, so they are tied on overall pts.
+		// A beats B 1-0 in H2H, so A should rank above B.
+		// A: 2W 0L = 6pts (beat B 1-0, beat C 1-0)
+		// B: 1W 1L = 3pts (lost to A 0-1, beat C 2-0)
+		// C: 0W 2L = 0pts
 		$this->create_match( $this->club_a, $this->club_b, 1, 0 );
-		$this->create_match( $this->club_c, $this->club_a, 2, 0 );
+		$this->create_match( $this->club_a, $this->club_c, 1, 0 );
 		$this->create_match( $this->club_b, $this->club_c, 2, 0 );
 
 		update_option( 'wpcm_standings_orderby', 'pts' );
@@ -207,28 +207,16 @@ class HeadToHeadSortTest extends WPCMTestCase {
 		$clubs = $this->build_clubs_for_sort();
 		usort( $clubs, 'wpcm_sort_table_clubs' );
 
-		// Pairwise H2H is circular (A>B, B>C, C>A) so we only verify
-		// the deterministic pair: A must rank above B.
-		$a_pos = null;
-		$b_pos = null;
-		foreach ( $clubs as $pos => $club ) {
-			if ( $club->ID === $this->club_a ) {
-				$a_pos = $pos;
-			}
-			if ( $club->ID === $this->club_b ) {
-				$b_pos = $pos;
-			}
-		}
-		$this->assertNotNull( $a_pos, 'Club A must be in sorted results' );
-		$this->assertNotNull( $b_pos, 'Club B must be in sorted results' );
-		$this->assertLessThan( $b_pos, $a_pos, 'Club A should rank higher than Club B due to H2H win' );
+		$this->assertEquals( $this->club_a, $clubs[0]->ID, 'Club A should be 1st (most pts)' );
+		$this->assertEquals( $this->club_b, $clubs[1]->ID, 'Club B should be 2nd' );
+		$this->assertEquals( $this->club_c, $clubs[2]->ID, 'Club C should be 3rd (0 pts)' );
 	}
 
 	public function test_h2h_falls_through_to_next_priority_when_tied() {
 		// A and B draw 0-0 in their only H2H match.
 		// A also beats C 3-0, B also beats C 1-0.
-		// A: 1W 1D 0L = 4pts, F=3 A=0 GD=+3
-		// B: 1W 1D 0L = 4pts, F=1 A=0 GD=+1
+		// A: 1W 1D 0L = 4pts, F=3 A=0 GD=+3 (H2H: 1pt)
+		// B: 1W 1D 0L = 4pts, F=1 A=0 GD=+1 (H2H: 1pt)
 		$this->create_match( $this->club_a, $this->club_b, 0, 0 );
 		$this->create_match( $this->club_a, $this->club_c, 3, 0 );
 		$this->create_match( $this->club_b, $this->club_c, 1, 0 );
@@ -267,6 +255,33 @@ class HeadToHeadSortTest extends WPCMTestCase {
 		// Only the competitive match counts: B won, A lost.
 		$this->assertEquals( 0, $result['a_points'] );
 		$this->assertEquals( 3, $result['b_points'] );
+	}
+
+	public function test_h2h_excludes_postponed_without_walkover() {
+		// Postponed match without walkover should be excluded.
+		$postponed = $this->create_match( $this->club_a, $this->club_b, 0, 0 );
+		update_post_meta( $postponed, '_wpcm_postponed', '1' );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 0, $result['a_points'] );
+		$this->assertEquals( 0, $result['b_points'] );
+	}
+
+	public function test_h2h_includes_walkover_results() {
+		// Postponed match with home_win walkover should count.
+		$walkover = $this->create_match( $this->club_a, $this->club_b, 0, 0 );
+		update_post_meta( $walkover, '_wpcm_postponed', '1' );
+		update_post_meta( $walkover, '_wpcm_walkover', 'home_win' );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 3, $result['a_points'] );
+		$this->assertEquals( 0, $result['b_points'] );
 	}
 
 	public function test_h2h_with_no_direct_matches_returns_zero() {

--- a/tests/wpunit/HeadToHeadSortTest.php
+++ b/tests/wpunit/HeadToHeadSortTest.php
@@ -186,46 +186,20 @@ class HeadToHeadSortTest extends WPCMTestCase {
 	// -----------------------------------------------------------------------
 
 	public function test_h2h_tiebreaker_ranks_winner_higher() {
-		// Set up: A and B have identical records vs C but A beat B directly.
-		// A beats C 2-0, B beats C 2-0, A beats B 1-0.
-		$this->create_match( $this->club_a, $this->club_c, 2, 0 );
+		// A beats B 1-0, C beats A 2-0, B beats C 2-0.
+		// A: 1W 1L = 3pts, F=1 A=2 GD=-1
+		// B: 1W 1L = 3pts, F=2 A=1 GD=+1
+		// C: 1W 1L = 3pts, F=2 A=2 GD=0
+		// All tied on pts. H2H (priority 2) breaks A vs B: A beat B 1-0.
+		$this->create_match( $this->club_a, $this->club_b, 1, 0 );
+		$this->create_match( $this->club_c, $this->club_a, 2, 0 );
 		$this->create_match( $this->club_b, $this->club_c, 2, 0 );
-		$this->create_match( $this->club_a, $this->club_b, 1, 0 );
 
-		// A: 2W 0D 0L, 6pts, F=3 A=0 GD=+3
-		// B: 1W 0D 1L, 3pts, F=2 A=1 GD=+1
-		// C: 0W 0D 2L, 0pts, F=0 A=4 GD=-4
-		// A is clearly ahead, but let's test with matching points.
-
-		// Better scenario: both tied on points, GD, goals.
-		// A beats B 1-0, B beats C 2-0, C beats A 1-0.
-		// Each has: 1W 0D 1L = 3pts, GD=+0 ... let's check:
-		// A: F=1+0=1, A=0+1=1, GD=0
-		// B: F=0+2=2, A=1+0=1, GD=+1
-		// Not equal GD. Let me design it more carefully.
-
-		// Reset - recreate with precise scenario.
-		foreach ( $this->match_ids as $id ) {
-			wp_delete_post( $id, true );
-		}
-		$this->match_ids = array();
-
-		// A beats B 1-0, B beats A 0-1 ... that means 2 matches between A and B.
-		// Let me use a triangular scenario where all 3 have same pts and GD:
-		// A beats B 1-0
-		// B beats C 1-0
-		// C beats A 1-0
-		// Each team: 1W 0D 1L, 3pts, F=1, A=1, GD=0
-		$this->create_match( $this->club_a, $this->club_b, 1, 0 );
-		$this->create_match( $this->club_b, $this->club_c, 1, 0 );
-		$this->create_match( $this->club_c, $this->club_a, 1, 0 );
-
-		// Configure sorting: pts first, then H2H.
 		update_option( 'wpcm_standings_orderby', 'pts' );
 		update_option( 'wpcm_standings_priority_order', 'DESC' );
 		update_option( 'wpcm_standings_orderby_2', 'h2h' );
 		update_option( 'wpcm_standings_priority_order_2', 'DESC' );
-		update_option( 'wpcm_standings_orderby_3', 'f' );
+		update_option( 'wpcm_standings_orderby_3', 'gd' );
 		update_option( 'wpcm_standings_priority_order_3', 'DESC' );
 
 		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
@@ -233,28 +207,31 @@ class HeadToHeadSortTest extends WPCMTestCase {
 		$clubs = $this->build_clubs_for_sort();
 		usort( $clubs, 'wpcm_sort_table_clubs' );
 
-		// All three have 3pts, 0 GD, same F. H2H between adjacent pairs:
-		// The sort compares pairs. When comparing A vs B: A beat B, so A > B.
-		// When comparing A vs C: C beat A, so C > A.
-		// When comparing B vs C: B beat C, so B > C.
-		// Expected order: C, A, B (C beat A, A beat B, B beat C — circular, but
-		// usort compares pairs so: C > A > B).
-		$this->assertEquals( $this->club_c, $clubs[0]->ID );
-		$this->assertEquals( $this->club_a, $clubs[1]->ID );
-		$this->assertEquals( $this->club_b, $clubs[2]->ID );
+		// Pairwise H2H is circular (A>B, B>C, C>A) so we only verify
+		// the deterministic pair: A must rank above B.
+		$a_pos = null;
+		$b_pos = null;
+		foreach ( $clubs as $pos => $club ) {
+			if ( $club->ID === $this->club_a ) {
+				$a_pos = $pos;
+			}
+			if ( $club->ID === $this->club_b ) {
+				$b_pos = $pos;
+			}
+		}
+		$this->assertNotNull( $a_pos, 'Club A must be in sorted results' );
+		$this->assertNotNull( $b_pos, 'Club B must be in sorted results' );
+		$this->assertLessThan( $b_pos, $a_pos, 'Club A should rank higher than Club B due to H2H win' );
 	}
 
 	public function test_h2h_falls_through_to_next_priority_when_tied() {
 		// A and B draw 0-0 in their only H2H match.
 		// A also beats C 3-0, B also beats C 1-0.
-		// Both have same pts (6) but A has more goals.
+		// A: 1W 1D 0L = 4pts, F=3 A=0 GD=+3
+		// B: 1W 1D 0L = 4pts, F=1 A=0 GD=+1
 		$this->create_match( $this->club_a, $this->club_b, 0, 0 );
 		$this->create_match( $this->club_a, $this->club_c, 3, 0 );
 		$this->create_match( $this->club_b, $this->club_c, 1, 0 );
-
-		// A: 1W 1D 0L = 4pts, F=3 A=0 GD=+3
-		// B: 1W 1D 0L = 4pts, F=1 A=0 GD=+1
-		// C: 0W 0D 2L = 0pts
 
 		update_option( 'wpcm_standings_orderby', 'pts' );
 		update_option( 'wpcm_standings_priority_order', 'DESC' );


### PR DESCRIPTION
## Summary

- Adds head-to-head (H2H) record as a sorting priority option in League Table settings
- When two clubs are tied on preceding priorities, their direct match results are compared: H2H points → H2H goal difference → H2H goals scored
- H2H comparison respects competition/season context and excludes friendly matches

## Changes

| File | Change |
|------|--------|
| `includes/wpcm-standings-functions.php` | Added `wpcm_set_h2h_context()`, `wpcm_clear_h2h_context()`, `wpcm_get_h2h_points()` functions; modified `wpcm_sort_table_clubs()` to handle `h2h` column |
| `includes/shortcodes/class-wpcm-shortcode-league-table.php` | Sets H2H context (comp/season) before sorting, clears after |
| `includes/admin/settings/class-wpcm-settings-standings.php` | Added "Head-to-Head Record" option to sorting priority dropdowns |
| `tests/wpunit/HeadToHeadSortTest.php` | Unit tests for H2H points, goal difference, sorting, fallthrough, friendly exclusion |

## Test plan

- [ ] Verify H2H option appears in League Tables → Sorting settings
- [ ] Create a league table where two clubs are tied on points
- [ ] Set Priority 2 to "Head-to-Head Record" and confirm the club with the better H2H record ranks higher
- [ ] Verify friendly matches are excluded from H2H calculations
- [ ] Verify that when H2H is also tied, sorting falls through to the next priority
- [ ] Run WPUnit tests: `HeadToHeadSortTest`

Closes #98