### PR TITLE
[Feature] Option to remove link on player photo in gallery (#97)

### DIFF
--- a/includes/shortcodes/class-wpcm-shortcode-player-gallery.php
+++ b/includes/shortcodes/class-wpcm-shortcode-player-gallery.php
@@ -47,6 +47,7 @@ class WPCM_Shortcode_Player_Gallery {
 		$linktext    = ( isset( $atts['linktext'] ) ? $atts['linktext'] : __( 'View all players', 'wp-club-manager' ) );
 		$linkpage    = ( isset( $atts['linkpage'] ) ? $atts['linkpage'] : null );
 		$name_format = ( isset( $atts['name_format'] ) ? $atts['name_format'] : 'full' );
+		$linkimage   = ( isset( $atts['linkimage'] ) ? $atts['linkimage'] : 'yes' );
 		$type        = ( isset( $atts['type'] ) ? $atts['type'] : '' );
 
 		if ( '' === $limit ) {
@@ -66,6 +67,9 @@ class WPCM_Shortcode_Player_Gallery {
 		}
 		if ( '' === $name_format ) {
 			$name_format = 'full';
+		}
+		if ( '' === $linkimage ) {
+			$linkimage = 'yes';
 		}
 		if ( '' === $linkpage ) {
 			$linkpage = null;
@@ -129,9 +133,17 @@ class WPCM_Shortcode_Player_Gallery {
 					$url          = get_permalink( $player->ID );
 					$player_title = get_player_title( $player->ID, $name_format );
 
-					$player_details[ $player->ID ]['image'] = apply_filters( 'wpclubmanager_player_gallery_image', '<a href="' . esc_url( $url ) . '">' . $thumb . '</a>', $url, $thumb );
+					if ( 'no' === $linkimage ) {
+						$image_html = $thumb;
+						$title_html = wp_kses_post( $player_title );
+					} else {
+						$image_html = '<a href="' . esc_url( $url ) . '">' . $thumb . '</a>';
+						$title_html = '<a href="' . esc_url( $url ) . '">' . wp_kses_post( $player_title ) . '</a>';
+					}
 
-					$player_details[ $player->ID ]['title'] = apply_filters( 'wpclubmanager_player_gallery_title', '<a href="' . esc_url( $url ) . '">' . wp_kses_post( $player_title ) . '</a>', $url, $player_title );
+					$player_details[ $player->ID ]['image'] = apply_filters( 'wpclubmanager_player_gallery_image', $image_html, $url, $thumb );
+
+					$player_details[ $player->ID ]['title'] = apply_filters( 'wpclubmanager_player_gallery_title', $title_html, $url, $player_title );
 
 					if ( array_key_exists( $orderby, $player_stats_labels ) ) {
 						if ( $team ) {

--- a/includes/shortcodes/class-wpcm-shortcode-player-gallery.php
+++ b/includes/shortcodes/class-wpcm-shortcode-player-gallery.php
@@ -47,7 +47,7 @@ class WPCM_Shortcode_Player_Gallery {
 		$linktext    = ( isset( $atts['linktext'] ) ? $atts['linktext'] : __( 'View all players', 'wp-club-manager' ) );
 		$linkpage    = ( isset( $atts['linkpage'] ) ? $atts['linkpage'] : null );
 		$name_format = ( isset( $atts['name_format'] ) ? $atts['name_format'] : 'full' );
-		$linkimage   = ( isset( $atts['linkimage'] ) ? $atts['linkimage'] : 'yes' );
+		$linkimage   = ( isset( $atts['linkimage'] ) ? strtolower( trim( $atts['linkimage'] ) ) : 'yes' );
 		$type        = ( isset( $atts['type'] ) ? $atts['type'] : '' );
 
 		if ( '' === $limit ) {

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -556,6 +556,10 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 			global $post;
 		}
 
+		if ( $post instanceof WP_Post ) {
+			$post = $post->ID;
+		}
+
 		$output  = array();
 		$teams   = wp_get_object_terms( $post, 'wpcm_team', array( 'orderby' => 'tax_position' ) );
 		$seasons = wp_get_object_terms( $post, 'wpcm_season', array( 'orderby' => 'tax_position' ) );

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -589,7 +589,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 
 		// combined season stats for combined team
 		$stats        = get_wpcm_player_auto_stats( $post );
-		$manual_stats = get_wpcm_player_manual_stats( $post, $team->term_id, $season->term_id );
+		$manual_stats = get_wpcm_player_manual_stats( $post );
 		$output[0][0] = array(
 			'auto'   => $stats,
 			'total'  => $stats,

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -546,7 +546,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 	/**
 	 * Get total player stats.
 	 *
-	 * @param WP_Post $post
+	 * @param WP_Post|int|null $post Player post object or ID.
 	 *
 	 * @return array
 	 */
@@ -556,13 +556,11 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 			global $post;
 		}
 
-		if ( $post instanceof WP_Post ) {
-			$post = $post->ID;
-		}
+		$post_id = ( $post instanceof WP_Post ) ? $post->ID : $post;
 
 		$output  = array();
-		$teams   = wp_get_object_terms( $post, 'wpcm_team', array( 'orderby' => 'tax_position' ) );
-		$seasons = wp_get_object_terms( $post, 'wpcm_season', array( 'orderby' => 'tax_position' ) );
+		$teams   = wp_get_object_terms( $post_id, 'wpcm_team', array( 'orderby' => 'tax_position' ) );
+		$seasons = wp_get_object_terms( $post_id, 'wpcm_season', array( 'orderby' => 'tax_position' ) );
 
 		// isolated team stats
 		if ( is_array( $teams ) ) {
@@ -570,7 +568,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 			foreach ( $teams as $team ) {
 
 				// combined season stats per team
-				$stats                       = get_wpcm_player_auto_stats( $post, $team->term_id, null );
+				$stats                       = get_wpcm_player_auto_stats( $post_id, $team->term_id, null );
 				$output[ $team->term_id ][0] = array(
 					'auto'  => $stats,
 					'total' => $stats,
@@ -581,7 +579,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 
 					foreach ( $seasons as $season ) {
 
-						$stats                                        = get_wpcm_player_auto_stats( $post, $team->term_id, $season->term_id );
+						$stats                                        = get_wpcm_player_auto_stats( $post_id, $team->term_id, $season->term_id );
 						$output[ $team->term_id ][ $season->term_id ] = array(
 							'auto'  => $stats,
 							'total' => $stats,
@@ -592,8 +590,8 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 		}
 
 		// combined season stats for combined team
-		$stats        = get_wpcm_player_auto_stats( $post );
-		$manual_stats = get_wpcm_player_manual_stats( $post );
+		$stats        = get_wpcm_player_auto_stats( $post_id );
+		$manual_stats = get_wpcm_player_manual_stats( $post_id );
 		$output[0][0] = array(
 			'auto'   => $stats,
 			'total'  => $stats,
@@ -605,7 +603,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 
 			foreach ( $seasons as $season ) {
 
-				$stats                         = get_wpcm_player_auto_stats( $post, null, $season->term_id );
+				$stats                         = get_wpcm_player_auto_stats( $post_id, null, $season->term_id );
 				$output[0][ $season->term_id ] = array(
 					'auto'  => $stats,
 					'total' => $stats,
@@ -614,7 +612,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 		}
 
 		// manual stats
-		$manual_stats = (array) maybe_unserialize( get_post_meta( $post, 'wpcm_stats', true ) );
+		$manual_stats = (array) maybe_unserialize( get_post_meta( $post_id, 'wpcm_stats', true ) );
 
 		if ( is_array( $manual_stats ) ) {
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1746,33 +1746,13 @@ parameters:
 			path: includes/wpcm-stats-functions.php
 
 		-
-			message: "#^Parameter \\#2 \\$team of function get_wpcm_player_manual_stats expects string\\|null, int given\\.$#"
-			count: 1
-			path: includes/wpcm-stats-functions.php
-
-		-
 			message: "#^Parameter \\#3 \\$season of function get_wpcm_club_auto_stats expects int\\|null, string\\|null given\\.$#"
-			count: 1
-			path: includes/wpcm-stats-functions.php
-
-		-
-			message: "#^Parameter \\#3 \\$season of function get_wpcm_player_manual_stats expects string\\|null, int given\\.$#"
 			count: 1
 			path: includes/wpcm-stats-functions.php
 
 		-
 			message: "#^Parameter \\#3 \\$season_id of function get_wpcm_player_auto_stats expects string\\|null, int given\\.$#"
 			count: 2
-			path: includes/wpcm-stats-functions.php
-
-		-
-			message: "#^Variable \\$season might not be defined\\.$#"
-			count: 1
-			path: includes/wpcm-stats-functions.php
-
-		-
-			message: "#^Variable \\$team might not be defined\\.$#"
-			count: 1
 			path: includes/wpcm-stats-functions.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -446,11 +446,6 @@ parameters:
 			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-stats.php
 
 		-
-			message: "#^Parameter \\#1 \\$post of function get_wpcm_player_stats expects WP_Post\\|null, int given\\.$#"
-			count: 1
-			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-stats.php
-
-		-
 			message: "#^Parameter \\#1 \\$post_id of function get_post_meta expects int, string given\\.$#"
 			count: 1
 			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-stats.php
@@ -1381,19 +1376,9 @@ parameters:
 			path: includes/shortcodes/class-wpcm-shortcode-match-opponents.php
 
 		-
-			message: "#^Parameter \\#1 \\$post of function get_wpcm_player_stats expects WP_Post\\|null, int given\\.$#"
-			count: 1
-			path: includes/shortcodes/class-wpcm-shortcode-player-gallery.php
-
-		-
 			message: "#^Variable \\$transient_name might not be defined\\.$#"
 			count: 2
 			path: includes/shortcodes/class-wpcm-shortcode-player-gallery.php
-
-		-
-			message: "#^Parameter \\#1 \\$post of function get_wpcm_player_stats expects WP_Post\\|null, int given\\.$#"
-			count: 1
-			path: includes/shortcodes/class-wpcm-shortcode-player-list.php
 
 		-
 			message: "#^Undefined variable\\: \\$natl$#"
@@ -1442,11 +1427,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$args of function get_posts expects array\\{numberposts\\?\\: int, category\\?\\: int\\|string, include\\?\\: array\\<int\\>, exclude\\?\\: array\\<int\\>, suppress_filters\\?\\: bool, attachment_id\\?\\: int, author\\?\\: int\\|string, author_name\\?\\: string, \\.\\.\\.\\}\\|null, array\\{post_type\\: 'wpcm_player', tax_query\\: array\\{\\}\\|array\\{0\\: array\\{taxonomy\\: 'wpcm_season', terms\\: mixed, field\\: 'term_id'\\}, 1\\?\\: array\\{taxonomy\\: 'wpcm_position'\\|'wpcm_team', terms\\: mixed, field\\: 'term_id'\\}, 2\\?\\: array\\{taxonomy\\: 'wpcm_position', terms\\: mixed, field\\: 'term_id'\\}\\}\\|array\\{0\\: array\\{taxonomy\\: 'wpcm_team', terms\\: mixed, field\\: 'term_id'\\}, 1\\?\\: array\\{taxonomy\\: 'wpcm_position', terms\\: mixed, field\\: 'term_id'\\}\\}\\|array\\{array\\{taxonomy\\: 'wpcm_position', terms\\: mixed, field\\: 'term_id'\\}\\}, numposts\\: mixed, posts_per_page\\: mixed, orderby\\: 'menu_order'\\|'meta_value_num'\\|'name', meta_key\\: 'wpcm_number', order\\: string, suppress_filters\\: 0\\} given\\.$#"
-			count: 1
-			path: includes/shortcodes/legacy/class-wpcm-shortcode-players.php
-
-		-
-			message: "#^Parameter \\#1 \\$post of function get_wpcm_player_stats expects WP_Post\\|null, int given\\.$#"
 			count: 1
 			path: includes/shortcodes/legacy/class-wpcm-shortcode-players.php
 

--- a/tests/wpunit/PlayerGalleryLinkTest.php
+++ b/tests/wpunit/PlayerGalleryLinkTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests for the player_gallery shortcode linkimage attribute.
+ *
+ * Verifies that the linkimage attribute controls whether player
+ * photos and names are wrapped in links to the player profile.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/97
+ */
+
+class PlayerGalleryLinkTest extends WPCMTestCase {
+
+	/** @var int */
+	private $roster_id;
+
+	/** @var int */
+	private $player_id;
+
+	/** @var int */
+	private $season_id;
+
+	/** @var int */
+	private $team_id;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		// Disable shortcode output caching for tests.
+		update_option( 'wpcm_disable_cache', 'yes' );
+
+		// Create a season and team term.
+		$season           = wp_insert_term( 'Test Season', 'wpcm_season' );
+		$this->season_id  = $season['term_id'];
+		$team             = wp_insert_term( 'Test Team', 'wpcm_team' );
+		$this->team_id    = $team['term_id'];
+
+		// Create a player.
+		$this->player_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_player',
+			'post_title'  => 'Gallery Player',
+			'post_status' => 'publish',
+		) );
+		update_post_meta( $this->player_id, 'wpcm_number', '10' );
+
+		// Create a roster and assign the player.
+		$this->roster_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_roster',
+			'post_title'  => 'Test Roster',
+			'post_status' => 'publish',
+		) );
+		update_post_meta( $this->roster_id, '_wpcm_roster_players', array( $this->player_id ) );
+		wp_set_object_terms( $this->roster_id, $this->season_id, 'wpcm_season' );
+		wp_set_object_terms( $this->roster_id, $this->team_id, 'wpcm_team' );
+	}
+
+	public function _tearDown() {
+		wp_delete_post( $this->roster_id, true );
+		wp_delete_post( $this->player_id, true );
+		wp_delete_term( $this->season_id, 'wpcm_season' );
+		wp_delete_term( $this->team_id, 'wpcm_team' );
+		parent::_tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// Default behaviour — images are linked
+	// -----------------------------------------------------------------------
+
+	public function test_player_gallery_image_is_linked_by_default() {
+		$output = do_shortcode( '[player_gallery id="' . $this->roster_id . '"]' );
+		$url    = get_permalink( $this->player_id );
+
+		$this->assertStringContainsString( '<a href="' . esc_url( $url ) . '">', $output );
+	}
+
+	// -----------------------------------------------------------------------
+	// linkimage="no" — images are NOT linked
+	// -----------------------------------------------------------------------
+
+	public function test_player_gallery_image_not_linked_when_linkimage_no() {
+		$output = do_shortcode( '[player_gallery id="' . $this->roster_id . '" linkimage="no"]' );
+		$url    = get_permalink( $this->player_id );
+
+		$this->assertStringNotContainsString( '<a href="' . esc_url( $url ) . '">', $output );
+		// The image should still be rendered, just without the link.
+		$this->assertStringContainsString( 'wpcm-players-gallery', $output );
+	}
+
+	// -----------------------------------------------------------------------
+	// linkimage="yes" — explicit yes still links
+	// -----------------------------------------------------------------------
+
+	public function test_player_gallery_image_linked_when_linkimage_yes() {
+		$output = do_shortcode( '[player_gallery id="' . $this->roster_id . '" linkimage="yes"]' );
+		$url    = get_permalink( $this->player_id );
+
+		$this->assertStringContainsString( '<a href="' . esc_url( $url ) . '">', $output );
+	}
+}

--- a/tests/wpunit/PlayerGalleryLinkTest.php
+++ b/tests/wpunit/PlayerGalleryLinkTest.php
@@ -29,10 +29,18 @@ class PlayerGalleryLinkTest extends WPCMTestCase {
 		update_option( 'wpcm_disable_cache', 'yes' );
 
 		// Create a season and team term.
-		$season           = wp_insert_term( 'Test Season', 'wpcm_season' );
-		$this->season_id  = $season['term_id'];
-		$team             = wp_insert_term( 'Test Team', 'wpcm_team' );
-		$this->team_id    = $team['term_id'];
+		$season = wp_insert_term( 'Test Season', 'wpcm_season' );
+		if ( is_wp_error( $season ) ) {
+			$this->season_id = $season->get_error_data();
+		} else {
+			$this->season_id = $season['term_id'];
+		}
+		$team = wp_insert_term( 'Test Team', 'wpcm_team' );
+		if ( is_wp_error( $team ) ) {
+			$this->team_id = $team->get_error_data();
+		} else {
+			$this->team_id = $team['term_id'];
+		}
 
 		// Create a player.
 		$this->player_id = wp_insert_post( array(
@@ -70,6 +78,7 @@ class PlayerGalleryLinkTest extends WPCMTestCase {
 		$url    = get_permalink( $this->player_id );
 
 		$this->assertStringContainsString( '<a href="' . esc_url( $url ) . '">', $output );
+		$this->assertStringContainsString( '<h4><a href="' . esc_url( $url ) . '">', $output );
 	}
 
 	// -----------------------------------------------------------------------
@@ -81,6 +90,7 @@ class PlayerGalleryLinkTest extends WPCMTestCase {
 		$url    = get_permalink( $this->player_id );
 
 		$this->assertStringNotContainsString( '<a href="' . esc_url( $url ) . '">', $output );
+		$this->assertStringNotContainsString( '<h4><a href="' . esc_url( $url ) . '">', $output );
 		// The image should still be rendered, just without the link.
 		$this->assertStringContainsString( 'wpcm-players-gallery', $output );
 	}
@@ -94,5 +104,6 @@ class PlayerGalleryLinkTest extends WPCMTestCase {
 		$url    = get_permalink( $this->player_id );
 
 		$this->assertStringContainsString( '<a href="' . esc_url( $url ) . '">', $output );
+		$this->assertStringContainsString( '<h4><a href="' . esc_url( $url ) . '">', $output );
 	}
 }

--- a/tests/wpunit/PlayerGalleryLinkTest.php
+++ b/tests/wpunit/PlayerGalleryLinkTest.php
@@ -75,10 +75,10 @@ class PlayerGalleryLinkTest extends WPCMTestCase {
 
 	public function test_player_gallery_image_is_linked_by_default() {
 		$output = do_shortcode( '[player_gallery id="' . $this->roster_id . '"]' );
-		$url    = get_permalink( $this->player_id );
+		$url    = preg_quote( esc_url( get_permalink( $this->player_id ) ), '/' );
 
-		$this->assertStringContainsString( '<a href="' . esc_url( $url ) . '">', $output );
-		$this->assertStringContainsString( '<h4><a href="' . esc_url( $url ) . '">', $output );
+		$this->assertMatchesRegularExpression( '/<a\s[^>]*href="' . $url . '"/', $output );
+		$this->assertMatchesRegularExpression( '/<h4>\s*<a\s[^>]*href="' . $url . '"/', $output );
 	}
 
 	// -----------------------------------------------------------------------
@@ -87,10 +87,10 @@ class PlayerGalleryLinkTest extends WPCMTestCase {
 
 	public function test_player_gallery_image_not_linked_when_linkimage_no() {
 		$output = do_shortcode( '[player_gallery id="' . $this->roster_id . '" linkimage="no"]' );
-		$url    = get_permalink( $this->player_id );
+		$url    = preg_quote( esc_url( get_permalink( $this->player_id ) ), '/' );
 
-		$this->assertStringNotContainsString( '<a href="' . esc_url( $url ) . '">', $output );
-		$this->assertStringNotContainsString( '<h4><a href="' . esc_url( $url ) . '">', $output );
+		$this->assertDoesNotMatchRegularExpression( '/<a\s[^>]*href="' . $url . '"/', $output );
+		$this->assertDoesNotMatchRegularExpression( '/<h4>\s*<a\s[^>]*href="' . $url . '"/', $output );
 		// The image should still be rendered, just without the link.
 		$this->assertStringContainsString( 'wpcm-players-gallery', $output );
 	}
@@ -101,9 +101,9 @@ class PlayerGalleryLinkTest extends WPCMTestCase {
 
 	public function test_player_gallery_image_linked_when_linkimage_yes() {
 		$output = do_shortcode( '[player_gallery id="' . $this->roster_id . '" linkimage="yes"]' );
-		$url    = get_permalink( $this->player_id );
+		$url    = preg_quote( esc_url( get_permalink( $this->player_id ) ), '/' );
 
-		$this->assertStringContainsString( '<a href="' . esc_url( $url ) . '">', $output );
-		$this->assertStringContainsString( '<h4><a href="' . esc_url( $url ) . '">', $output );
+		$this->assertMatchesRegularExpression( '/<a\s[^>]*href="' . $url . '"/', $output );
+		$this->assertMatchesRegularExpression( '/<h4>\s*<a\s[^>]*href="' . $url . '"/', $output );
 	}
 }

--- a/tests/wpunit/PlayerStatsTest.php
+++ b/tests/wpunit/PlayerStatsTest.php
@@ -118,6 +118,57 @@ class PlayerStatsTest extends WPCMTestCase {
 	}
 
 	// -----------------------------------------------------------------------
+	// get_wpcm_player_stats() — combined manual stats
+	// -----------------------------------------------------------------------
+
+	public function test_get_wpcm_player_stats_combined_manual_stats_uses_combined_entry() {
+		$team = wp_insert_term( 'Stats Team', 'wpcm_team' );
+		if ( is_wp_error( $team ) ) {
+			$team_id = $team->get_error_data();
+		} else {
+			$team_id = $team['term_id'];
+		}
+
+		$season = wp_insert_term( 'Stats Season', 'wpcm_season' );
+		if ( is_wp_error( $season ) ) {
+			$season_id = $season->get_error_data();
+		} else {
+			$season_id = $season['term_id'];
+		}
+
+		wp_set_object_terms( $this->player_id, $team_id, 'wpcm_team' );
+		wp_set_object_terms( $this->player_id, $season_id, 'wpcm_season' );
+
+		// Store manual stats under the combined key (0,0) and a per-team key.
+		$stats = array(
+			0        => array(
+				0 => array(
+					'appearances' => 12,
+					'goals'       => 8,
+				),
+			),
+			$team_id => array(
+				$season_id => array(
+					'appearances' => 5,
+					'goals'       => 2,
+				),
+			),
+		);
+
+		update_post_meta( $this->player_id, 'wpcm_stats', serialize( $stats ) );
+
+		$result = get_wpcm_player_stats( $this->player_id );
+
+		// The combined entry should use the (0,0) manual stats, not the per-team values.
+		$this->assertArrayHasKey( 'manual', $result[0][0] );
+		$this->assertEquals( 12, $result[0][0]['manual']['appearances'] );
+		$this->assertEquals( 8, $result[0][0]['manual']['goals'] );
+
+		wp_delete_term( $team_id, 'wpcm_team' );
+		wp_delete_term( $season_id, 'wpcm_season' );
+	}
+
+	// -----------------------------------------------------------------------
 	// get_wpcm_player_stats_empty_row()
 	// -----------------------------------------------------------------------
 

--- a/tests/wpunit/PlayerStatsTest.php
+++ b/tests/wpunit/PlayerStatsTest.php
@@ -121,7 +121,7 @@ class PlayerStatsTest extends WPCMTestCase {
 	// get_wpcm_player_stats() — combined manual stats
 	// -----------------------------------------------------------------------
 
-	public function test_get_wpcm_player_stats_combined_manual_stats_uses_combined_entry() {
+	public function test_get_wpcm_player_stats_combined_manual_stats_does_not_use_per_team_values() {
 		$team = wp_insert_term( 'Stats Team', 'wpcm_team' );
 		if ( is_wp_error( $team ) ) {
 			$team_id = $team->get_error_data();
@@ -130,6 +130,50 @@ class PlayerStatsTest extends WPCMTestCase {
 		}
 
 		$season = wp_insert_term( 'Stats Season', 'wpcm_season' );
+		if ( is_wp_error( $season ) ) {
+			$season_id = $season->get_error_data();
+		} else {
+			$season_id = $season['term_id'];
+		}
+
+		wp_set_object_terms( $this->player_id, $team_id, 'wpcm_team' );
+		wp_set_object_terms( $this->player_id, $season_id, 'wpcm_season' );
+
+		// Only store per-team stats — no (0,0) combined entry.
+		// Before the fix, the combined entry would pick up per-team values
+		// because stale loop variables were passed to get_wpcm_player_manual_stats().
+		$stats = array(
+			$team_id => array(
+				$season_id => array(
+					'appearances' => 5,
+					'goals'       => 2,
+				),
+			),
+		);
+
+		update_post_meta( $this->player_id, 'wpcm_stats', serialize( $stats ) );
+
+		$result = get_wpcm_player_stats( $this->player_id );
+
+		// The combined entry should use the (0,0) manual stats (empty defaults),
+		// NOT the per-team values that would leak via stale loop variables.
+		$this->assertArrayHasKey( 'manual', $result[0][0] );
+		$this->assertEquals( 0, $result[0][0]['manual']['appearances'] );
+		$this->assertEquals( 0, $result[0][0]['manual']['goals'] );
+
+		wp_delete_term( $team_id, 'wpcm_team' );
+		wp_delete_term( $season_id, 'wpcm_season' );
+	}
+
+	public function test_get_wpcm_player_stats_combined_manual_stats_uses_combined_entry() {
+		$team = wp_insert_term( 'Stats Team 2', 'wpcm_team' );
+		if ( is_wp_error( $team ) ) {
+			$team_id = $team->get_error_data();
+		} else {
+			$team_id = $team['term_id'];
+		}
+
+		$season = wp_insert_term( 'Stats Season 2', 'wpcm_season' );
 		if ( is_wp_error( $season ) ) {
 			$season_id = $season->get_error_data();
 		} else {
@@ -159,7 +203,7 @@ class PlayerStatsTest extends WPCMTestCase {
 
 		$result = get_wpcm_player_stats( $this->player_id );
 
-		// The combined entry should use the (0,0) manual stats, not the per-team values.
+		// When (0,0) exists, it should be used for the combined entry.
 		$this->assertArrayHasKey( 'manual', $result[0][0] );
 		$this->assertEquals( 12, $result[0][0]['manual']['appearances'] );
 		$this->assertEquals( 8, $result[0][0]['manual']['goals'] );


### PR DESCRIPTION
## Summary

- Adds a `linkimage` attribute to the `[player_gallery]` shortcode
- When set to `"no"`, player photos and names are rendered without links to the player profile
- Defaults to `"yes"` (existing behaviour preserved)
- Fixes `get_wpcm_player_stats()` combined manual stats using stale loop variables instead of the combined (0,0) entry

## Usage

```
[player_gallery id="123" linkimage="no"]
```

## Changes

| File | Change |
|------|--------|
| `includes/shortcodes/class-wpcm-shortcode-player-gallery.php` | Add `linkimage` attribute, conditionally wrap image/title in links |
| `includes/wpcm-stats-functions.php` | Fix `get_wpcm_player_stats()` to call `get_wpcm_player_manual_stats()` without team/season args for the combined entry, avoiding use of stale loop variables |
| `tests/wpunit/PlayerGalleryLinkTest.php` | WPUnit tests for default, `linkimage="yes"`, and `linkimage="no"` |
| `tests/wpunit/PlayerStatsTest.php` | WPUnit test verifying combined manual stats use the (0,0) entry |

## Test plan

- [ ] Verify `[player_gallery id="X"]` still wraps photos in links (default)
- [ ] Verify `[player_gallery id="X" linkimage="yes"]` wraps photos in links
- [ ] Verify `[player_gallery id="X" linkimage="no"]` renders photos without links
- [ ] Verify player names also follow the `linkimage` setting
- [ ] CI: WPUnit tests pass
- [ ] CI: PHPStan passes with updated baseline

Closes #97