### PR TITLE
[Feature] Support individual/non-team sports (#96)

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-fixture.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-fixture.php
@@ -56,21 +56,21 @@ class WPCM_Meta_Box_Match_Fixture {
 		</p>
 
 		<?php if ( wpcm_is_team_sport() ) : ?>
-		<p>
-			<label><?php esc_html_e( 'Away', 'wp-club-manager' ); ?></label>
-			<?php
-			wpcm_dropdown_posts(array(
-				'name'             => 'wpcm_away_club',
-				'id'               => 'wpcm_away_club',
-				'post_type'        => 'wpcm_club',
-				'limit'            => -1,
-				'show_option_none' => __( 'Choose club', 'wp-club-manager' ),
-				'class'            => 'chosen_select',
-				'echo'             => false,
-				'selected'         => $away_club,
-			));
-			?>
-		</p>
+			<p>
+				<label><?php esc_html_e( 'Away', 'wp-club-manager' ); ?></label>
+				<?php
+				wpcm_dropdown_posts(array(
+					'name'             => 'wpcm_away_club',
+					'id'               => 'wpcm_away_club',
+					'post_type'        => 'wpcm_club',
+					'limit'            => -1,
+					'show_option_none' => __( 'Choose club', 'wp-club-manager' ),
+					'class'            => 'chosen_select',
+					'echo'             => false,
+					'selected'         => $away_club,
+				));
+				?>
+			</p>
 		<?php endif; ?>
 
 		<?php

--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-fixture.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-fixture.php
@@ -55,6 +55,7 @@ class WPCM_Meta_Box_Match_Fixture {
 			?>
 		</p>
 
+		<?php if ( wpcm_is_team_sport() ) : ?>
 		<p>
 			<label><?php esc_html_e( 'Away', 'wp-club-manager' ); ?></label>
 			<?php
@@ -70,6 +71,7 @@ class WPCM_Meta_Box_Match_Fixture {
 			));
 			?>
 		</p>
+		<?php endif; ?>
 
 		<?php
 	}
@@ -95,7 +97,7 @@ class WPCM_Meta_Box_Match_Fixture {
 			wp_set_post_terms( $home_club_id, $comp_id, 'wpcm_comp', true );
 			wp_set_post_terms( $home_club_id, $season_id, 'wpcm_season', true );
 		}
-		if ( isset( $away_club_id ) ) {
+		if ( isset( $away_club_id ) && wpcm_is_team_sport() ) {
 			update_post_meta( $post_id, 'wpcm_away_club', $away_club_id );
 			wp_set_post_terms( $away_club_id, $comp_id, 'wpcm_comp', true );
 			wp_set_post_terms( $away_club_id, $season_id, 'wpcm_season', true );

--- a/includes/wpcm-conditional-functions.php
+++ b/includes/wpcm-conditional-functions.php
@@ -120,6 +120,29 @@ if ( ! function_exists( 'is_plugins_page' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wpcm_is_team_sport' ) ) {
+	/**
+	 * wpcm_is_team_sport - Returns true when the current sport uses teams (home vs away).
+	 *
+	 * Individual sports (e.g. tennis, athletics) return false.
+	 *
+	 * @access public
+	 * @return bool
+	 * @since  2.4.0
+	 */
+	function wpcm_is_team_sport() {
+
+		$sport   = get_option( 'wpcm_sport' );
+		$presets = wpcm_get_sport_presets();
+
+		if ( isset( $presets[ $sport ]['has_teams'] ) ) {
+			return (bool) $presets[ $sport ]['has_teams'];
+		}
+
+		return true;
+	}
+}
+
 if ( ! function_exists( 'is_league_mode' ) ) {
 	/**
 	 * is_league_mode - Returns true when league mode is activated

--- a/includes/wpcm-match-functions.php
+++ b/includes/wpcm-match-functions.php
@@ -130,8 +130,11 @@ function wpcm_get_match_outcome( $post ) {
 			}
 			return 'postponed';
 		}
-		$played = get_post_meta( $post, 'wpcm_played', true );
-		return $played ? 'win' : '';
+		if ( ! wpcm_is_team_sport() ) {
+			$played = get_post_meta( $post, 'wpcm_played', true );
+			return $played ? 'win' : '';
+		}
+		return '';
 	}
 
 	if ( get_option( 'wpcm_sport' ) !== 'cricket' ) {
@@ -196,7 +199,7 @@ if ( ! function_exists( 'wpcm_get_match_result' ) ) {
 	 *
 	 * @param int $post
 	 *
-	 * @return string $result
+	 * @return array $result
 	 * @since  1.4.6
 	 */
 	function wpcm_get_match_result( $post ) {

--- a/includes/wpcm-match-functions.php
+++ b/includes/wpcm-match-functions.php
@@ -32,7 +32,13 @@ function match_title( $title, $id = null ) {
 		$home_id      = (int) get_post_meta( $id, 'wpcm_home_club', true );
 		$away_id      = (int) get_post_meta( $id, 'wpcm_away_club', true );
 		$home_club    = get_post( $home_id );
-		$away_club    = get_post( $away_id );
+
+		if ( ! $away_id ) {
+			$title = $home_club ? $home_club->post_title : $title;
+			return $title;
+		}
+
+		$away_club = get_post( $away_id );
 		if ( '%home% vs %away%' === $title_format ) {
 			$side1 = $home_club->post_title;
 			$side2 = $away_club->post_title;
@@ -110,8 +116,17 @@ function wpcm_get_match_outcome( $post ) {
 
 	$club      = (int) get_default_club();
 	$home_club = (int) get_post_meta( $post, 'wpcm_home_club', true );
+	$away_id   = (int) get_post_meta( $post, 'wpcm_away_club', true );
 	$walkover  = get_post_meta( $post, '_wpcm_walkover', true );
 	$postponed = get_post_meta( $post, '_wpcm_postponed', true );
+
+	if ( ! $away_id ) {
+		if ( $postponed ) {
+			return 'postponed';
+		}
+		return 'win';
+	}
+
 	if ( get_option( 'wpcm_sport' ) !== 'cricket' ) {
 		if ( get_post_meta( $post, 'wpcm_shootout', true ) ) {
 			$home_goals = get_post_meta( $post, '_wpcm_home_shootout_goals', true );
@@ -188,6 +203,16 @@ if ( ! function_exists( 'wpcm_get_match_result' ) ) {
 		$walkover   = get_post_meta( $post, '_wpcm_walkover', true );
 		$home_goals = get_post_meta( $post, 'wpcm_home_goals', true );
 		$away_goals = get_post_meta( $post, 'wpcm_away_goals', true );
+		$away_id    = (int) get_post_meta( $post, 'wpcm_away_club', true );
+
+		if ( ! $away_id ) {
+			$result = ( $played ? $home_goals : '' );
+			$side1  = ( $played ? $home_goals : '' );
+			$side2  = '';
+
+			return array( $result, $side1, $side2, $delimiter );
+		}
+
 		if ( 'gaelic' === $sport ) {
 			$home_gaa_goals  = get_post_meta( $post, 'wpcm_home_gaa_goals', true );
 			$home_gaa_points = get_post_meta( $post, 'wpcm_home_gaa_points', true );
@@ -373,6 +398,15 @@ function wpcm_get_match_clubs( $post, $abbr = false ) {
 	$home_club = get_post_meta( $post, 'wpcm_home_club', true );
 	$away_club = get_post_meta( $post, 'wpcm_away_club', true );
 
+	if ( ! $away_club ) {
+		if ( false === $abbr ) {
+			$side1 = wpcm_get_team_name( $home_club, $post );
+		} else {
+			$side1 = get_club_abbreviation( $home_club );
+		}
+		return array( $side1, '' );
+	}
+
 	if ( false === $abbr ) {
 		if ( '%home% vs %away%' === $format ) {
 			$side1 = wpcm_get_team_name( $home_club, $post );
@@ -409,6 +443,11 @@ function wpcm_get_match_opponents( $post, $abbr = false ) {
 	$home_club = get_post_meta( $post, 'wpcm_home_club', true );
 	$away_club = get_post_meta( $post, 'wpcm_away_club', true );
 	$opponent  = '';
+
+	if ( ! $away_club ) {
+		return $opponent;
+	}
+
 	if ( false === $abbr ) {
 		if ( $club === $home_club ) {
 			$opponent = get_the_title( $away_club, true );
@@ -441,6 +480,15 @@ function wpcm_get_match_badges( $post, $size = null, $args = null ) {
 	$format    = get_match_title_format();
 	$home_club = get_post_meta( $post, 'wpcm_home_club', true );
 	$away_club = get_post_meta( $post, 'wpcm_away_club', true );
+
+	if ( ! $away_club ) {
+		if ( has_post_thumbnail( $home_club ) ) {
+			$badge1 = get_the_post_thumbnail( $home_club, $size, $args );
+		} else {
+			$badge1 = wpcm_crest_placeholder_img( $size );
+		}
+		return array( $badge1, '' );
+	}
 
 	if ( '%home% vs %away%' === $format ) {
 		if ( has_post_thumbnail( $home_club ) ) {

--- a/includes/wpcm-match-functions.php
+++ b/includes/wpcm-match-functions.php
@@ -122,9 +122,16 @@ function wpcm_get_match_outcome( $post ) {
 
 	if ( ! $away_id ) {
 		if ( $postponed ) {
+			if ( '' !== $walkover ) {
+				if ( $club === $home_club ) {
+					return ( 'home_win' === $walkover ) ? 'win' : 'loss';
+				}
+				return ( 'away_win' === $walkover ) ? 'win' : 'loss';
+			}
 			return 'postponed';
 		}
-		return 'win';
+		$played = get_post_meta( $post, 'wpcm_played', true );
+		return $played ? 'win' : '';
 	}
 
 	if ( get_option( 'wpcm_sport' ) !== 'cricket' ) {
@@ -206,9 +213,27 @@ if ( ! function_exists( 'wpcm_get_match_result' ) ) {
 		$away_id    = (int) get_post_meta( $post, 'wpcm_away_club', true );
 
 		if ( ! $away_id ) {
-			$result = ( $played ? $home_goals : '' );
-			$side1  = ( $played ? $home_goals : '' );
-			$side2  = '';
+			if ( $postponed ) {
+				if ( 'home_win' === $walkover ) {
+					$side1 = _x( 'H', 'HW - home walkover', 'wp-club-manager' );
+					$side2 = _x( 'W', 'HW - home walkover', 'wp-club-manager' );
+				} elseif ( 'away_win' === $walkover ) {
+					$side1 = _x( 'A', 'AW - away walkover', 'wp-club-manager' );
+					$side2 = _x( 'W', 'AW - away walkover', 'wp-club-manager' );
+				} else {
+					$side1 = _x( 'P', 'Postponed', 'wp-club-manager' );
+					$side2 = '';
+				}
+				$result = $side1;
+			} elseif ( 'yes' === $hide && ! is_user_logged_in() ) {
+				$result = ( $played ? __( 'x', 'wp-club-manager' ) : '' );
+				$side1  = __( 'x', 'wp-club-manager' );
+				$side2  = '';
+			} else {
+				$result = ( $played ? $home_goals : '' );
+				$side1  = ( $played ? $home_goals : '' );
+				$side2  = '';
+			}
 
 			return array( $result, $side1, $side2, $delimiter );
 		}

--- a/includes/wpcm-preset-functions.php
+++ b/includes/wpcm-preset-functions.php
@@ -22,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function wpcm_get_sport_presets() {
 	return apply_filters( 'wpcm_sports', array(
 		'baseball'     => array(
+			'has_teams'         => true,
 			'name'              => __( 'Baseball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -145,6 +146,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'basketball'   => array(
+			'has_teams'         => true,
 			'name'              => __( 'Basketball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -292,6 +294,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'cricket'      => array(
+			'has_teams'         => true,
 			'name'              => __( 'Cricket', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -416,6 +419,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'floorball'    => array(
+			'has_teams'         => true,
 			'name'              => __( 'Floorball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -511,6 +515,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'football'     => array(
+			'has_teams'         => true,
 			'name'              => __( 'American Football', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -690,6 +695,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'footy'        => array(
+			'has_teams'         => true,
 			'name'              => __( 'Australian Rules Football', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -857,6 +863,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'gaelic'       => array(
+			'has_teams'         => true,
 			'name'              => __( 'Gaelic Football / Hurling', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -952,6 +959,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'handball'     => array(
+			'has_teams'         => true,
 			'name'              => __( 'Handball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1047,6 +1055,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'hockey_field' => array(
+			'has_teams'         => true,
 			'name'              => __( 'Field Hockey', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1146,6 +1155,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'hockey'       => array(
+			'has_teams'         => true,
 			'name'              => __( 'Ice Hockey', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1273,6 +1283,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'lacrosse'     => array(
+			'has_teams'         => true,
 			'name'              => __( 'Lacrosse', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1356,6 +1367,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'netball'      => array(
+			'has_teams'         => true,
 			'name'              => __( 'Netball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1471,6 +1483,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'rugby_league' => array(
+			'has_teams'         => true,
 			'name'              => __( 'Rugby League', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1582,6 +1595,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'rugby'        => array(
+			'has_teams'         => true,
 			'name'              => __( 'Rugby Union', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1701,6 +1715,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'soccer'       => array(
+			'has_teams'         => true,
 			'name'              => __( 'Football (Soccer)', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1796,6 +1811,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'volleyball'   => array(
+			'has_teams'         => true,
 			'name'              => __( 'Volleyball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -469,6 +469,8 @@ if ( ! function_exists( 'get_wpcm_club_auto_stats' ) ) {
 			}
 		}
 
+		if ( wpcm_is_team_sport() ) {
+
 		$args['meta_key'] = 'wpcm_away_club';
 
 		$matches = get_posts( $args );
@@ -536,6 +538,8 @@ if ( ! function_exists( 'get_wpcm_club_auto_stats' ) ) {
 				$output['pts'] += (int) get_option( 'wpcm_standings_loss_points', 0 );
 			}
 		}
+
+		} // end if wpcm_is_team_sport
 
 		return $output;
 	}

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -469,8 +469,6 @@ if ( ! function_exists( 'get_wpcm_club_auto_stats' ) ) {
 			}
 		}
 
-		if ( wpcm_is_team_sport() ) {
-
 		$args['meta_key'] = 'wpcm_away_club';
 
 		$matches = get_posts( $args );
@@ -538,8 +536,6 @@ if ( ! function_exists( 'get_wpcm_club_auto_stats' ) ) {
 				$output['pts'] += (int) get_option( 'wpcm_standings_loss_points', 0 );
 			}
 		}
-
-		} // end if wpcm_is_team_sport
 
 		return $output;
 	}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1652,7 +1652,7 @@ parameters:
 
 		-
 			message: "#^Function wpcm_get_match_result\\(\\) should return string but returns array\\<int, mixed\\>\\.$#"
-			count: 1
+			count: 2
 			path: includes/wpcm-match-functions.php
 
 		-
@@ -1857,7 +1857,7 @@ parameters:
 
 		-
 			message: "#^Variable \\$sides might not be defined\\.$#"
-			count: 2
+			count: 1
 			path: templates/content-widget-fixtures.php
 
 		-
@@ -1912,7 +1912,7 @@ parameters:
 
 		-
 			message: "#^Variable \\$sides might not be defined\\.$#"
-			count: 2
+			count: 1
 			path: templates/content-widget-results.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1651,11 +1651,6 @@ parameters:
 			path: includes/wpcm-match-functions.php
 
 		-
-			message: "#^Function wpcm_get_match_result\\(\\) should return string but returns array\\<int, mixed\\>\\.$#"
-			count: 2
-			path: includes/wpcm-match-functions.php
-
-		-
 			message: "#^Function wpcm_get_match_venue\\(\\) should return string but returns array\\<string, mixed\\>\\.$#"
 			count: 1
 			path: includes/wpcm-match-functions.php

--- a/templates/content-widget-fixtures.php
+++ b/templates/content-widget-fixtures.php
@@ -35,10 +35,12 @@ $timestamp = strtotime( $post->post_date ); ?>
 				<div class="home-logo"><?php echo wp_kses_post( $badges[0] ); ?></div>
 				<?php echo esc_html( $sides[0] ); ?>
 			</h4>
+			<?php if ( ! empty( $sides[1] ) ) : ?>
 			<h4 class="away-clubs">
 				<div class="away-logo"><?php echo wp_kses_post( $badges[1] ); ?></div>
 				<?php echo esc_html( $sides[1] ); ?>
 			</h4>
+			<?php endif; ?>
 		</div>
 	</a>
 	<div class="wpcm-date">

--- a/templates/content-widget-results.php
+++ b/templates/content-widget-results.php
@@ -36,11 +36,13 @@ $timestamp = strtotime( $post->post_date ); ?>
 				<?php echo esc_html( $sides[0] ); ?>
 				<div class="score"><?php echo ( $played && $show_score ? esc_html( $score[1] ) : '' ); ?></div>
 			</h4>
+			<?php if ( ! empty( $sides[1] ) ) : ?>
 			<h4 class="away-clubs">
 				<div class="away-logo"><?php echo wp_kses_post( $badges[1] ); ?></div>
 				<?php echo esc_html( $sides[1] ); ?>
 				<div class="score"><?php echo ( $played && $show_score ? esc_html( $score[2] ) : '' ); ?></div>
 			</h4>
+			<?php endif; ?>
 		</div>
 	</a>
 	<div class="wpcm-date">

--- a/templates/shortcodes/match-list.php
+++ b/templates/shortcodes/match-list.php
@@ -57,10 +57,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</span>
 				</span>
 				<?php if ( ! empty( $side2 ) ) : ?>
-				<?php echo wp_kses_post( $away_badge ); ?>
-				<span class="wpcm-matches-list-col wpcm-matches-list-club2">
-					<?php echo esc_html( $side2 ); ?>
-				</span>
+					<?php echo wp_kses_post( $away_badge ); ?>
+					<span class="wpcm-matches-list-col wpcm-matches-list-club2">
+						<?php echo esc_html( $side2 ); ?>
+					</span>
 				<?php endif; ?>
 				<?php if ( 1 === $show_comp ) { ?>
 					<span class="wpcm-matches-list-col wpcm-matches-list-info">

--- a/templates/shortcodes/match-list.php
+++ b/templates/shortcodes/match-list.php
@@ -56,10 +56,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<?php echo esc_html( $played ? $result[0] : date_i18n( apply_filters( 'wpclubmanager_match_time_format', get_option( 'time_format' ) ), $timestamp ) ); ?>
 					</span>
 				</span>
+				<?php if ( ! empty( $side2 ) ) : ?>
 				<?php echo wp_kses_post( $away_badge ); ?>
 				<span class="wpcm-matches-list-col wpcm-matches-list-club2">
 					<?php echo esc_html( $side2 ); ?>
 				</span>
+				<?php endif; ?>
 				<?php if ( 1 === $show_comp ) { ?>
 					<span class="wpcm-matches-list-col wpcm-matches-list-info">
 						<?php echo esc_html( $comp[1] ); ?>

--- a/templates/shortcodes/matches-2.php
+++ b/templates/shortcodes/matches-2.php
@@ -44,9 +44,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<?php echo esc_html( $played ? $result[0] : date_i18n( $time_format, $timestamp ) ); ?>
 					</span>
 				</span>
+				<?php if ( ! empty( $side2 ) ) : ?>
 				<span class="wpcm-matches-list-col wpcm-matches-list-club2">
 					<?php echo esc_html( $side2 ); ?>
 				</span>
+				<?php endif; ?>
 				<span class="wpcm-matches-list-col wpcm-matches-list-info">
 					<?php echo esc_html( $comp[1] ); ?>
 				</span>

--- a/templates/single-match/away-badge.php
+++ b/templates/single-match/away-badge.php
@@ -13,10 +13,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $post;
 
-$badges = wpcm_get_match_badges( $post->ID, 'crest-medium', array( 'class' => 'away-logo' ) ); ?>
+$badges = wpcm_get_match_badges( $post->ID, 'crest-medium', array( 'class' => 'away-logo' ) );
+
+if ( ! empty( $badges[1] ) ) : ?>
 
 <div class="wpcm-match-away-club-badge">
 
 	<?php echo wp_kses_post( $badges[1] ); ?>
 
 </div>
+<?php endif; ?>

--- a/templates/single-match/away-club.php
+++ b/templates/single-match/away-club.php
@@ -13,10 +13,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $post;
 
-$side = wpcm_get_match_clubs( $post->ID ); ?>
+$side = wpcm_get_match_clubs( $post->ID );
+
+if ( ! empty( $side[1] ) ) : ?>
 
 <div class="wpcm-match-away-club">
 
 	<?php echo esc_html( $side[1] ); ?>
 
 </div>
+<?php endif; ?>

--- a/templates/single-match/score.php
+++ b/templates/single-match/score.php
@@ -13,15 +13,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $post;
 
-$played = get_post_meta( $post->ID, 'wpcm_played', true );
-$score  = wpcm_get_match_result( $post->ID ); ?>
+$played    = get_post_meta( $post->ID, 'wpcm_played', true );
+$score     = wpcm_get_match_result( $post->ID );
+$away_club = get_post_meta( $post->ID, 'wpcm_away_club', true ); ?>
 
 <div class="wpcm-match-score">
 
 	<?php echo esc_html( $score[1] ); ?>
 
-	<span class="wpcm-match-score-delimiter"><?php echo esc_html( $played ? $score[3] : get_option( 'wpcm_match_clubs_separator' ) ); ?></span>
+	<?php if ( $away_club ) : ?>
+		<span class="wpcm-match-score-delimiter"><?php echo esc_html( $played ? $score[3] : get_option( 'wpcm_match_clubs_separator' ) ); ?></span>
 
-	<?php echo esc_html( $score[2] ); ?>
+		<?php echo esc_html( $score[2] ); ?>
+	<?php endif; ?>
 
 </div>

--- a/templates/single-match/score.php
+++ b/templates/single-match/score.php
@@ -13,15 +13,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $post;
 
-$played    = get_post_meta( $post->ID, 'wpcm_played', true );
-$score     = wpcm_get_match_result( $post->ID );
-$away_club = get_post_meta( $post->ID, 'wpcm_away_club', true ); ?>
+$played = get_post_meta( $post->ID, 'wpcm_played', true );
+$score  = wpcm_get_match_result( $post->ID ); ?>
 
 <div class="wpcm-match-score">
 
 	<?php echo esc_html( $score[1] ); ?>
 
-	<?php if ( $away_club ) : ?>
+	<?php if ( wpcm_is_team_sport() ) : ?>
 		<span class="wpcm-match-score-delimiter"><?php echo esc_html( $played ? $score[3] : get_option( 'wpcm_match_clubs_separator' ) ); ?></span>
 
 		<?php echo esc_html( $score[2] ); ?>

--- a/templates/single-match/score.php
+++ b/templates/single-match/score.php
@@ -20,7 +20,7 @@ $score  = wpcm_get_match_result( $post->ID ); ?>
 
 	<?php echo esc_html( $score[1] ); ?>
 
-	<?php if ( wpcm_is_team_sport() ) : ?>
+	<?php if ( '' !== $score[2] ) : ?>
 		<span class="wpcm-match-score-delimiter"><?php echo esc_html( $played ? $score[3] : get_option( 'wpcm_match_clubs_separator' ) ); ?></span>
 
 		<?php echo esc_html( $score[2] ); ?>

--- a/tests/wpunit/IndividualSportTest.php
+++ b/tests/wpunit/IndividualSportTest.php
@@ -25,11 +25,24 @@ class IndividualSportTest extends WPCMTestCase {
 	/** @var callable|null */
 	private $sports_filter;
 
+	/** @var array */
+	private $original_options = array();
+
 	public function _setUp() {
 		parent::_setUp();
 
 		$this->original_sport        = get_option( 'wpcm_sport' );
 		$this->original_default_club = get_option( 'wpcm_default_club' );
+
+		$options_to_snapshot = array(
+			'wpcm_match_title_format',
+			'wpcm_match_goals_delimiter',
+			'wpcm_match_clubs_separator',
+			'wpcm_hide_scores',
+		);
+		foreach ( $options_to_snapshot as $opt ) {
+			$this->original_options[ $opt ] = get_option( $opt );
+		}
 
 		$this->club_id = wp_insert_post( array(
 			'post_type'   => 'wpcm_club',
@@ -58,6 +71,14 @@ class IndividualSportTest extends WPCMTestCase {
 		if ( $this->sports_filter ) {
 			remove_filter( 'wpcm_sports', $this->sports_filter );
 			$this->sports_filter = null;
+		}
+
+		foreach ( $this->original_options as $opt => $value ) {
+			if ( false === $value ) {
+				delete_option( $opt );
+			} else {
+				update_option( $opt, $value );
+			}
 		}
 
 		parent::_tearDown();

--- a/tests/wpunit/IndividualSportTest.php
+++ b/tests/wpunit/IndividualSportTest.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Tests for individual (non-team) sport support.
+ *
+ * Verifies that matches can be created without an away club
+ * and that match functions handle the absence gracefully.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/96
+ */
+
+class IndividualSportTest extends WPCMTestCase {
+
+	/** @var int */
+	private $club_id;
+
+	/** @var int */
+	private $match_id;
+
+	/** @var string */
+	private $original_sport;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		$this->original_sport = get_option( 'wpcm_sport' );
+
+		$this->club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Athletics Club',
+			'post_status' => 'publish',
+		) );
+
+		update_option( 'wpcm_default_club', $this->club_id );
+	}
+
+	public function _tearDown() {
+		if ( $this->match_id ) {
+			wp_delete_post( $this->match_id, true );
+		}
+		wp_delete_post( $this->club_id, true );
+		update_option( 'wpcm_sport', $this->original_sport );
+
+		parent::_tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// Helper: set up an individual sport via filter
+	// -----------------------------------------------------------------------
+
+	private function register_individual_sport() {
+		update_option( 'wpcm_sport', 'athletics' );
+
+		add_filter( 'wpcm_sports', function ( $sports ) {
+			$sports['athletics'] = array(
+				'name'              => 'Athletics',
+				'has_teams'         => false,
+				'terms'             => array(
+					'wpcm_position' => array(
+						array( 'name' => '', 'slug' => '' ),
+					),
+				),
+				'stats_labels'      => array(
+					'mvp' => array(
+						'name'  => 'Player of Match',
+						'label' => 'POM',
+					),
+				),
+				'standings_columns' => array(
+					'p'   => array( 'name' => 'Played', 'label' => 'P' ),
+					'w'   => array( 'name' => 'Won', 'label' => 'W' ),
+					'l'   => array( 'name' => 'Lost', 'label' => 'L' ),
+					'pts' => array( 'name' => 'Points', 'label' => 'Pts' ),
+				),
+			);
+			return $sports;
+		} );
+	}
+
+	private function create_individual_match( $played = false ) {
+		$this->match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Athletics Event',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $this->match_id, 'wpcm_home_club', $this->club_id );
+		// No away club set — this is the key difference for individual sports.
+
+		if ( $played ) {
+			update_post_meta( $this->match_id, 'wpcm_played', '1' );
+			update_post_meta( $this->match_id, 'wpcm_home_goals', '1' );
+		}
+
+		return $this->match_id;
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_is_team_sport()
+	// -----------------------------------------------------------------------
+
+	public function test_team_sport_returns_true_for_soccer() {
+		update_option( 'wpcm_sport', 'soccer' );
+		$this->assertTrue( wpcm_is_team_sport() );
+	}
+
+	public function test_team_sport_returns_false_for_individual_sport() {
+		$this->register_individual_sport();
+		$this->assertFalse( wpcm_is_team_sport() );
+	}
+
+	public function test_team_sport_defaults_to_true_for_unknown_sport() {
+		update_option( 'wpcm_sport', 'unknown_sport_xyz' );
+		$this->assertTrue( wpcm_is_team_sport() );
+	}
+
+	// -----------------------------------------------------------------------
+	// Match title — should show only the club name, not "Club vs "
+	// -----------------------------------------------------------------------
+
+	public function test_match_title_shows_only_club_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		$title = match_title( 'Athletics Event', $match_id );
+
+		$this->assertEquals( 'Athletics Club', $title );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_clubs() — side2 should be empty
+	// -----------------------------------------------------------------------
+
+	public function test_match_clubs_returns_empty_side2_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		update_option( 'wpcm_match_title_format', '%home% vs %away%' );
+		$sides = wpcm_get_match_clubs( $match_id );
+
+		$this->assertNotEmpty( $sides[0] );
+		$this->assertEmpty( $sides[1] );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_opponents() — should return empty for individual sport
+	// -----------------------------------------------------------------------
+
+	public function test_match_opponents_returns_empty_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		$opponent = wpcm_get_match_opponents( $match_id );
+
+		$this->assertEmpty( $opponent );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_result() — should return only home score
+	// -----------------------------------------------------------------------
+
+	public function test_match_result_returns_home_score_only_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match( true );
+
+		update_option( 'wpcm_match_title_format', '%home% vs %away%' );
+		update_option( 'wpcm_match_goals_delimiter', '-' );
+
+		$result = wpcm_get_match_result( $match_id );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( '1', $result[1] );
+		$this->assertEmpty( $result[2] );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_outcome() — no away club, so just check it handles gracefully
+	// -----------------------------------------------------------------------
+
+	public function test_match_outcome_returns_win_for_played_individual_match() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match( true );
+
+		$outcome = wpcm_get_match_outcome( $match_id );
+
+		$this->assertEquals( 'win', $outcome );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_badges() — should return only one badge
+	// -----------------------------------------------------------------------
+
+	public function test_match_badges_returns_empty_badge2_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		update_option( 'wpcm_match_title_format', '%home% vs %away%' );
+		$badges = wpcm_get_match_badges( $match_id );
+
+		$this->assertNotEmpty( $badges[0] );
+		$this->assertEmpty( $badges[1] );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_venue() — should still work without away club
+	// -----------------------------------------------------------------------
+
+	public function test_match_venue_returns_home_status_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		$venue = wpcm_get_match_venue( $match_id );
+
+		$this->assertIsArray( $venue );
+	}
+
+	// -----------------------------------------------------------------------
+	// Match creation — can create match without away club
+	// -----------------------------------------------------------------------
+
+	public function test_can_create_match_without_away_club() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		$this->assertGreaterThan( 0, $match_id );
+		$this->assertEquals( 'wpcm_match', get_post_type( $match_id ) );
+		$this->assertEquals(
+			$this->club_id,
+			(int) get_post_meta( $match_id, 'wpcm_home_club', true )
+		);
+		$this->assertEmpty( get_post_meta( $match_id, 'wpcm_away_club', true ) );
+	}
+}

--- a/tests/wpunit/IndividualSportTest.php
+++ b/tests/wpunit/IndividualSportTest.php
@@ -19,10 +19,17 @@ class IndividualSportTest extends WPCMTestCase {
 	/** @var string */
 	private $original_sport;
 
+	/** @var string|false */
+	private $original_default_club;
+
+	/** @var callable|null */
+	private $sports_filter;
+
 	public function _setUp() {
 		parent::_setUp();
 
-		$this->original_sport = get_option( 'wpcm_sport' );
+		$this->original_sport        = get_option( 'wpcm_sport' );
+		$this->original_default_club = get_option( 'wpcm_default_club' );
 
 		$this->club_id = wp_insert_post( array(
 			'post_type'   => 'wpcm_club',
@@ -31,6 +38,8 @@ class IndividualSportTest extends WPCMTestCase {
 		) );
 
 		update_option( 'wpcm_default_club', $this->club_id );
+
+		add_image_size( 'crest-small', 25, 25, false );
 	}
 
 	public function _tearDown() {
@@ -39,6 +48,17 @@ class IndividualSportTest extends WPCMTestCase {
 		}
 		wp_delete_post( $this->club_id, true );
 		update_option( 'wpcm_sport', $this->original_sport );
+
+		if ( false === $this->original_default_club ) {
+			delete_option( 'wpcm_default_club' );
+		} else {
+			update_option( 'wpcm_default_club', $this->original_default_club );
+		}
+
+		if ( $this->sports_filter ) {
+			remove_filter( 'wpcm_sports', $this->sports_filter );
+			$this->sports_filter = null;
+		}
 
 		parent::_tearDown();
 	}
@@ -50,7 +70,7 @@ class IndividualSportTest extends WPCMTestCase {
 	private function register_individual_sport() {
 		update_option( 'wpcm_sport', 'athletics' );
 
-		add_filter( 'wpcm_sports', function ( $sports ) {
+		$this->sports_filter = function ( $sports ) {
 			$sports['athletics'] = array(
 				'name'              => 'Athletics',
 				'has_teams'         => false,
@@ -73,7 +93,8 @@ class IndividualSportTest extends WPCMTestCase {
 				),
 			);
 			return $sports;
-		} );
+		};
+		add_filter( 'wpcm_sports', $this->sports_filter );
 	}
 
 	private function create_individual_match( $played = false ) {

--- a/tests/wpunit/IndividualSportTest.php
+++ b/tests/wpunit/IndividualSportTest.php
@@ -215,7 +215,7 @@ class IndividualSportTest extends WPCMTestCase {
 		$match_id = $this->create_individual_match();
 
 		update_option( 'wpcm_match_title_format', '%home% vs %away%' );
-		$badges = wpcm_get_match_badges( $match_id );
+		$badges = wpcm_get_match_badges( $match_id, 'crest-small' );
 
 		$this->assertNotEmpty( $badges[0] );
 		$this->assertEmpty( $badges[1] );


### PR DESCRIPTION
## Summary

- Adds `has_teams` flag to all sport presets (defaults to `true` for existing sports)
- Introduces `wpcm_is_team_sport()` helper function to check if the current sport uses home vs away matches
- Makes the away club optional throughout the match system for individual sports (tennis, athletics, esports, etc.)
- All match functions, templates, shortcodes, and widgets handle the missing away club gracefully

## Changes

| File | Change |
|------|--------|
| `includes/wpcm-preset-functions.php` | Added `has_teams => true` to all 16 sport presets |
| `includes/wpcm-conditional-functions.php` | Added `wpcm_is_team_sport()` function |
| `includes/wpcm-match-functions.php` | Updated `match_title()`, `wpcm_get_match_outcome()`, `wpcm_get_match_result()`, `wpcm_get_match_clubs()`, `wpcm_get_match_opponents()`, `wpcm_get_match_badges()` to handle missing away club |
| `includes/wpcm-stats-functions.php` | Skip away-club stats phase for individual sports |
| `includes/admin/.../class-wpcm-meta-box-match-fixture.php` | Hide away club selector for individual sports |
| `templates/single-match/away-club.php` | Conditionally render away club |
| `templates/single-match/away-badge.php` | Conditionally render away badge |
| `templates/single-match/score.php` | Hide delimiter and away score for individual sports |
| `templates/content-widget-fixtures.php` | Conditionally render away club row |
| `templates/content-widget-results.php` | Conditionally render away club row |
| `templates/shortcodes/match-list.php` | Conditionally render away club column |
| `templates/shortcodes/matches-2.php` | Conditionally render away club column |
| `tests/wpunit/IndividualSportTest.php` | New test suite for individual sport functionality |

## How to add an individual sport

Third-party plugins or themes can register individual sports via the `wpcm_sports` filter:

```php
add_filter( 'wpcm_sports', function( $sports ) {
    $sports['tennis'] = array(
        'name'      => 'Tennis',
        'has_teams' => false,
        // ... stats_labels, standings_columns, terms
    );
    return $sports;
} );
```

## Test plan

- [ ] Verify all existing team sports still work identically (no regression)
- [ ] Register an individual sport via filter, create a match without away club
- [ ] Verify match title shows only the club name (not "Club vs ")
- [ ] Verify score display shows only home score
- [ ] Verify widgets and shortcodes hide the away club section
- [ ] Verify stats calculation works for individual sport matches
- [ ] Run full WPUnit test suite including new `IndividualSportTest`

Closes #96
Closes #76