### PR TITLE
Release v2.4.0

### DIFF
--- a/assets/css/wpclubmanager.css
+++ b/assets/css/wpclubmanager.css
@@ -1049,3 +1049,72 @@ ul.wpcm-matches-list {
 .leaflet-marker-icon {
 	box-shadow: none !important;
 }
+
+/* Match Calendar */
+.wpcm-calendar {
+	margin: 1em 0;
+}
+.wpcm-calendar-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 0.5em;
+	font-size: 1.1em;
+	font-weight: 600;
+}
+a.wpcm-calendar-nav {
+	cursor: pointer;
+	padding: 0.25em 0.5em;
+	user-select: none;
+	text-decoration: none;
+	color: inherit;
+}
+.wpcm-calendar-table {
+	width: 100%;
+	border-collapse: collapse;
+	table-layout: fixed;
+}
+.wpcm-calendar-table th {
+	text-align: center;
+	padding: 0.4em;
+	font-weight: 600;
+	border-bottom: 2px solid #ddd;
+}
+.wpcm-calendar-table td {
+	vertical-align: top;
+	padding: 0.3em;
+	border: 1px solid #eee;
+	height: 60px;
+}
+.wpcm-calendar-empty {
+	background: #fafafa;
+}
+.wpcm-calendar-day-number {
+	display: block;
+	font-weight: 600;
+	font-size: 0.85em;
+	margin-bottom: 0.2em;
+	color: #666;
+}
+.wpcm-calendar-has-match {
+	background: #f0f7ff;
+}
+.wpcm-calendar-match {
+	display: block;
+	font-size: 0.75em;
+	line-height: 1.3;
+	padding: 0.2em 0;
+	text-decoration: none;
+	color: inherit;
+}
+.wpcm-calendar-match:hover {
+	text-decoration: underline;
+}
+.wpcm-calendar-match-teams {
+	display: block;
+	font-weight: 600;
+}
+.wpcm-calendar-match-info {
+	display: block;
+	color: #888;
+}

--- a/assets/js/blocks/wpcm-blocks-editor.js
+++ b/assets/js/blocks/wpcm-blocks-editor.js
@@ -1,0 +1,433 @@
+/**
+ * WP Club Manager - Gutenberg Blocks
+ *
+ * Registers editor UI for all WPCM blocks using ServerSideRender.
+ * Each block delegates rendering to the corresponding shortcode class
+ * on the server, providing a live preview in the editor.
+ *
+ * @package WPClubManager
+ */
+
+( function() {
+	var el = wp.element.createElement;
+	var registerBlockType = wp.blocks.registerBlockType;
+	var blockEditor = wp.blockEditor || wp.editor;
+	var InspectorControls = blockEditor.InspectorControls;
+	var PanelBody = wp.components.PanelBody;
+	var TextControl = wp.components.TextControl;
+	var SelectControl = wp.components.SelectControl;
+	var ToggleControl = wp.components.ToggleControl;
+	var ServerSideRender = wp.serverSideRender;
+	var __ = wp.i18n.__;
+
+	var orderOptions = [
+		{ value: '', label: __( 'Default', 'wp-club-manager' ) },
+		{ value: 'ASC', label: __( 'Ascending', 'wp-club-manager' ) },
+		{ value: 'DESC', label: __( 'Descending', 'wp-club-manager' ) },
+	];
+
+	var nameFormatOptions = [
+		{ value: 'full', label: __( 'Full Name', 'wp-club-manager' ) },
+		{ value: 'last', label: __( 'Last Name', 'wp-club-manager' ) },
+		{ value: 'first', label: __( 'First Name', 'wp-club-manager' ) },
+	];
+
+	var formatOptions = [
+		{ value: '', label: __( 'All', 'wp-club-manager' ) },
+		{ value: 'fixtures', label: __( 'Fixtures', 'wp-club-manager' ) },
+		{ value: 'results', label: __( 'Results', 'wp-club-manager' ) },
+	];
+
+	var venueOptions = [
+		{ value: '', label: __( 'All', 'wp-club-manager' ) },
+		{ value: 'home', label: __( 'Home', 'wp-club-manager' ) },
+		{ value: 'away', label: __( 'Away', 'wp-club-manager' ) },
+	];
+
+	var dateRangeOptions = [
+		{ value: '', label: __( 'All', 'wp-club-manager' ) },
+		{ value: 'last_week', label: __( 'Last Week', 'wp-club-manager' ) },
+		{ value: 'next_week', label: __( 'Next Week', 'wp-club-manager' ) },
+	];
+
+	/**
+	 * Create a setter function for a specific attribute.
+	 */
+	function makeSetter( setAttributes, attr ) {
+		return function( value ) {
+			var update = {};
+			update[ attr ] = value;
+			setAttributes( update );
+		};
+	}
+
+	/**
+	 * Create a toggle setter that converts boolean to '1'/'0'.
+	 */
+	function makeToggleSetter( setAttributes, attr ) {
+		return function( value ) {
+			var update = {};
+			update[ attr ] = value ? '1' : '0';
+			setAttributes( update );
+		};
+	}
+
+	/**
+	 * Build an edit component from a block name and control definitions.
+	 */
+	function makeEdit( blockName, controls ) {
+		return function( props ) {
+			var attrs = props.attributes;
+			var setAttrs = props.setAttributes;
+
+			var controlElements = [];
+			for ( var i = 0; i < controls.length; i++ ) {
+				var c = controls[ i ];
+				if ( c.type === 'toggle' ) {
+					controlElements.push(
+						el( ToggleControl, {
+							key: c.attr,
+							label: c.label,
+							checked: attrs[ c.attr ] === '1',
+							onChange: makeToggleSetter( setAttrs, c.attr ),
+						} )
+					);
+				} else if ( c.type === 'select' ) {
+					controlElements.push(
+						el( SelectControl, {
+							key: c.attr,
+							label: c.label,
+							value: attrs[ c.attr ],
+							options: c.options,
+							onChange: makeSetter( setAttrs, c.attr ),
+						} )
+					);
+				} else {
+					controlElements.push(
+						el( TextControl, {
+							key: c.attr,
+							label: c.label,
+							value: attrs[ c.attr ] || '',
+							onChange: makeSetter( setAttrs, c.attr ),
+						} )
+					);
+				}
+			}
+
+			return el( 'div', { className: props.className },
+				el( InspectorControls, {},
+					el( PanelBody, { title: __( 'Settings', 'wp-club-manager' ) },
+						controlElements
+					)
+				),
+				el( ServerSideRender, {
+					block: blockName,
+					attributes: attrs,
+				} )
+			);
+		};
+	}
+
+	// -----------------------------------------------------------------------
+	// Match List
+	// -----------------------------------------------------------------------
+	registerBlockType( 'wpcm/match-list', {
+		title: __( 'Match List', 'wp-club-manager' ),
+		category: 'wp-club-manager',
+		icon: 'list-view',
+		description: __( 'Display a list of matches.', 'wp-club-manager' ),
+		attributes: {
+			title: { type: 'string', default: '' },
+			format: { type: 'string', default: '' },
+			limit: { type: 'string', default: '' },
+			comp: { type: 'string', default: '' },
+			season: { type: 'string', default: '' },
+			team: { type: 'string', default: '' },
+			venue: { type: 'string', default: '' },
+			date_range: { type: 'string', default: '' },
+			order: { type: 'string', default: '' },
+			show_abbr: { type: 'string', default: '0' },
+			show_thumb: { type: 'string', default: '0' },
+			show_comp: { type: 'string', default: '1' },
+			show_team: { type: 'string', default: '0' },
+			show_venue: { type: 'string', default: '0' },
+			linktext: { type: 'string', default: '' },
+			linkpage: { type: 'string', default: '' },
+		},
+		edit: makeEdit( 'wpcm/match-list', [
+			{ attr: 'title', label: __( 'Title', 'wp-club-manager' ) },
+			{ attr: 'format', label: __( 'Format', 'wp-club-manager' ), type: 'select', options: formatOptions },
+			{ attr: 'limit', label: __( 'Number of matches', 'wp-club-manager' ) },
+			{ attr: 'comp', label: __( 'Competition ID', 'wp-club-manager' ) },
+			{ attr: 'season', label: __( 'Season ID', 'wp-club-manager' ) },
+			{ attr: 'team', label: __( 'Team ID', 'wp-club-manager' ) },
+			{ attr: 'venue', label: __( 'Venue', 'wp-club-manager' ), type: 'select', options: venueOptions },
+			{ attr: 'date_range', label: __( 'Date Range', 'wp-club-manager' ), type: 'select', options: dateRangeOptions },
+			{ attr: 'order', label: __( 'Order', 'wp-club-manager' ), type: 'select', options: orderOptions },
+			{ attr: 'show_abbr', label: __( 'Show abbreviations', 'wp-club-manager' ), type: 'toggle' },
+			{ attr: 'show_thumb', label: __( 'Show club badges', 'wp-club-manager' ), type: 'toggle' },
+			{ attr: 'show_comp', label: __( 'Show competition', 'wp-club-manager' ), type: 'toggle' },
+			{ attr: 'show_team', label: __( 'Show team', 'wp-club-manager' ), type: 'toggle' },
+			{ attr: 'show_venue', label: __( 'Show venue', 'wp-club-manager' ), type: 'toggle' },
+			{ attr: 'linktext', label: __( 'Link text', 'wp-club-manager' ) },
+			{ attr: 'linkpage', label: __( 'Link page ID', 'wp-club-manager' ) },
+		] ),
+		save: function() { return null; },
+	} );
+
+	// -----------------------------------------------------------------------
+	// Player List
+	// -----------------------------------------------------------------------
+	registerBlockType( 'wpcm/player-list', {
+		title: __( 'Player List', 'wp-club-manager' ),
+		category: 'wp-club-manager',
+		icon: 'groups',
+		description: __( 'Display a list of players.', 'wp-club-manager' ),
+		attributes: {
+			id: { type: 'string', default: '' },
+			limit: { type: 'string', default: '' },
+			position: { type: 'string', default: '' },
+			orderby: { type: 'string', default: 'number' },
+			order: { type: 'string', default: 'ASC' },
+			linktext: { type: 'string', default: '' },
+			linkpage: { type: 'string', default: '' },
+			columns: { type: 'string', default: '' },
+			title: { type: 'string', default: '' },
+			name_format: { type: 'string', default: 'full' },
+			type: { type: 'string', default: '' },
+		},
+		edit: makeEdit( 'wpcm/player-list', [
+			{ attr: 'title', label: __( 'Title', 'wp-club-manager' ) },
+			{ attr: 'id', label: __( 'Roster ID', 'wp-club-manager' ) },
+			{ attr: 'limit', label: __( 'Number of players', 'wp-club-manager' ) },
+			{ attr: 'position', label: __( 'Position ID', 'wp-club-manager' ) },
+			{ attr: 'orderby', label: __( 'Order by', 'wp-club-manager' ) },
+			{ attr: 'order', label: __( 'Order', 'wp-club-manager' ), type: 'select', options: orderOptions },
+			{ attr: 'columns', label: __( 'Columns', 'wp-club-manager' ) },
+			{ attr: 'name_format', label: __( 'Name format', 'wp-club-manager' ), type: 'select', options: nameFormatOptions },
+			{ attr: 'linktext', label: __( 'Link text', 'wp-club-manager' ) },
+			{ attr: 'linkpage', label: __( 'Link page ID', 'wp-club-manager' ) },
+		] ),
+		save: function() { return null; },
+	} );
+
+	// -----------------------------------------------------------------------
+	// Player Gallery
+	// -----------------------------------------------------------------------
+	registerBlockType( 'wpcm/player-gallery', {
+		title: __( 'Player Gallery', 'wp-club-manager' ),
+		category: 'wp-club-manager',
+		icon: 'format-gallery',
+		description: __( 'Display a gallery of players.', 'wp-club-manager' ),
+		attributes: {
+			id: { type: 'string', default: '' },
+			title: { type: 'string', default: '' },
+			limit: { type: 'string', default: '' },
+			position: { type: 'string', default: '' },
+			orderby: { type: 'string', default: 'number' },
+			order: { type: 'string', default: 'ASC' },
+			columns: { type: 'string', default: '3' },
+			linktext: { type: 'string', default: '' },
+			linkpage: { type: 'string', default: '' },
+			name_format: { type: 'string', default: 'full' },
+			type: { type: 'string', default: '' },
+		},
+		edit: makeEdit( 'wpcm/player-gallery', [
+			{ attr: 'title', label: __( 'Title', 'wp-club-manager' ) },
+			{ attr: 'id', label: __( 'Roster ID', 'wp-club-manager' ) },
+			{ attr: 'limit', label: __( 'Number of players', 'wp-club-manager' ) },
+			{ attr: 'position', label: __( 'Position ID', 'wp-club-manager' ) },
+			{ attr: 'orderby', label: __( 'Order by', 'wp-club-manager' ) },
+			{ attr: 'order', label: __( 'Order', 'wp-club-manager' ), type: 'select', options: orderOptions },
+			{ attr: 'columns', label: __( 'Columns', 'wp-club-manager' ) },
+			{ attr: 'name_format', label: __( 'Name format', 'wp-club-manager' ), type: 'select', options: nameFormatOptions },
+			{ attr: 'linktext', label: __( 'Link text', 'wp-club-manager' ) },
+			{ attr: 'linkpage', label: __( 'Link page ID', 'wp-club-manager' ) },
+		] ),
+		save: function() { return null; },
+	} );
+
+	// -----------------------------------------------------------------------
+	// Staff List
+	// -----------------------------------------------------------------------
+	registerBlockType( 'wpcm/staff-list', {
+		title: __( 'Staff List', 'wp-club-manager' ),
+		category: 'wp-club-manager',
+		icon: 'businessman',
+		description: __( 'Display a list of staff members.', 'wp-club-manager' ),
+		attributes: {
+			id: { type: 'string', default: '' },
+			limit: { type: 'string', default: '' },
+			job: { type: 'string', default: '' },
+			orderby: { type: 'string', default: 'name' },
+			order: { type: 'string', default: 'ASC' },
+			linktext: { type: 'string', default: '' },
+			linkpage: { type: 'string', default: '' },
+			columns: { type: 'string', default: '' },
+			title: { type: 'string', default: '' },
+			name_format: { type: 'string', default: 'full' },
+			type: { type: 'string', default: '' },
+		},
+		edit: makeEdit( 'wpcm/staff-list', [
+			{ attr: 'title', label: __( 'Title', 'wp-club-manager' ) },
+			{ attr: 'id', label: __( 'ID', 'wp-club-manager' ) },
+			{ attr: 'limit', label: __( 'Number of staff', 'wp-club-manager' ) },
+			{ attr: 'job', label: __( 'Job ID', 'wp-club-manager' ) },
+			{ attr: 'orderby', label: __( 'Order by', 'wp-club-manager' ) },
+			{ attr: 'order', label: __( 'Order', 'wp-club-manager' ), type: 'select', options: orderOptions },
+			{ attr: 'columns', label: __( 'Columns', 'wp-club-manager' ) },
+			{ attr: 'name_format', label: __( 'Name format', 'wp-club-manager' ), type: 'select', options: nameFormatOptions },
+			{ attr: 'linktext', label: __( 'Link text', 'wp-club-manager' ) },
+			{ attr: 'linkpage', label: __( 'Link page ID', 'wp-club-manager' ) },
+		] ),
+		save: function() { return null; },
+	} );
+
+	// -----------------------------------------------------------------------
+	// Staff Gallery
+	// -----------------------------------------------------------------------
+	registerBlockType( 'wpcm/staff-gallery', {
+		title: __( 'Staff Gallery', 'wp-club-manager' ),
+		category: 'wp-club-manager',
+		icon: 'format-gallery',
+		description: __( 'Display a gallery of staff members.', 'wp-club-manager' ),
+		attributes: {
+			id: { type: 'string', default: '' },
+			title: { type: 'string', default: '' },
+			limit: { type: 'string', default: '' },
+			jobs: { type: 'string', default: '' },
+			orderby: { type: 'string', default: 'name' },
+			order: { type: 'string', default: 'ASC' },
+			columns: { type: 'string', default: '3' },
+			linktext: { type: 'string', default: '' },
+			linkpage: { type: 'string', default: '' },
+			name_format: { type: 'string', default: 'full' },
+			type: { type: 'string', default: '' },
+		},
+		edit: makeEdit( 'wpcm/staff-gallery', [
+			{ attr: 'title', label: __( 'Title', 'wp-club-manager' ) },
+			{ attr: 'id', label: __( 'ID', 'wp-club-manager' ) },
+			{ attr: 'limit', label: __( 'Number of staff', 'wp-club-manager' ) },
+			{ attr: 'jobs', label: __( 'Job IDs', 'wp-club-manager' ) },
+			{ attr: 'orderby', label: __( 'Order by', 'wp-club-manager' ) },
+			{ attr: 'order', label: __( 'Order', 'wp-club-manager' ), type: 'select', options: orderOptions },
+			{ attr: 'columns', label: __( 'Columns', 'wp-club-manager' ) },
+			{ attr: 'name_format', label: __( 'Name format', 'wp-club-manager' ), type: 'select', options: nameFormatOptions },
+			{ attr: 'linktext', label: __( 'Link text', 'wp-club-manager' ) },
+			{ attr: 'linkpage', label: __( 'Link page ID', 'wp-club-manager' ) },
+		] ),
+		save: function() { return null; },
+	} );
+
+	// -----------------------------------------------------------------------
+	// League Table
+	// -----------------------------------------------------------------------
+	registerBlockType( 'wpcm/league-table', {
+		title: __( 'League Table', 'wp-club-manager' ),
+		category: 'wp-club-manager',
+		icon: 'editor-table',
+		description: __( 'Display a league standings table.', 'wp-club-manager' ),
+		attributes: {
+			id: { type: 'string', default: '' },
+			title: { type: 'string', default: '' },
+			limit: { type: 'string', default: '' },
+			focus: { type: 'string', default: '' },
+			abbr: { type: 'string', default: '0' },
+			thumb: { type: 'string', default: '1' },
+			link_club: { type: 'string', default: '1' },
+			type: { type: 'string', default: '' },
+			notes: { type: 'string', default: '0' },
+			columns: { type: 'string', default: '' },
+			linktext: { type: 'string', default: '' },
+			linkpage: { type: 'string', default: '' },
+		},
+		edit: makeEdit( 'wpcm/league-table', [
+			{ attr: 'title', label: __( 'Title', 'wp-club-manager' ) },
+			{ attr: 'id', label: __( 'Table ID', 'wp-club-manager' ) },
+			{ attr: 'limit', label: __( 'Number of rows', 'wp-club-manager' ) },
+			{ attr: 'focus', label: __( 'Focus club ID', 'wp-club-manager' ) },
+			{ attr: 'columns', label: __( 'Columns', 'wp-club-manager' ) },
+			{ attr: 'abbr', label: __( 'Show abbreviations', 'wp-club-manager' ), type: 'toggle' },
+			{ attr: 'thumb', label: __( 'Show club badges', 'wp-club-manager' ), type: 'toggle' },
+			{ attr: 'link_club', label: __( 'Link to club', 'wp-club-manager' ), type: 'toggle' },
+			{ attr: 'notes', label: __( 'Show notes', 'wp-club-manager' ), type: 'toggle' },
+			{ attr: 'linktext', label: __( 'Link text', 'wp-club-manager' ) },
+			{ attr: 'linkpage', label: __( 'Link page ID', 'wp-club-manager' ) },
+		] ),
+		save: function() { return null; },
+	} );
+
+	// -----------------------------------------------------------------------
+	// Map Venue
+	// -----------------------------------------------------------------------
+	registerBlockType( 'wpcm/map-venue', {
+		title: __( 'Map Venue', 'wp-club-manager' ),
+		category: 'wp-club-manager',
+		icon: 'location-alt',
+		description: __( 'Display a venue map.', 'wp-club-manager' ),
+		attributes: {
+			id: { type: 'string', default: '' },
+			title: { type: 'string', default: '' },
+			width: { type: 'string', default: '' },
+			height: { type: 'string', default: '' },
+		},
+		edit: makeEdit( 'wpcm/map-venue', [
+			{ attr: 'title', label: __( 'Title', 'wp-club-manager' ) },
+			{ attr: 'id', label: __( 'Venue ID', 'wp-club-manager' ) },
+			{ attr: 'width', label: __( 'Width', 'wp-club-manager' ) },
+			{ attr: 'height', label: __( 'Height', 'wp-club-manager' ) },
+		] ),
+		save: function() { return null; },
+	} );
+
+	// -----------------------------------------------------------------------
+	// Match Opponents (club mode only — registered server-side conditionally)
+	// -----------------------------------------------------------------------
+	if ( window.wpcmBlocksConfig && window.wpcmBlocksConfig.clubMode ) {
+		registerBlockType( 'wpcm/match-opponents', {
+			title: __( 'Match Opponents', 'wp-club-manager' ),
+			category: 'wp-club-manager',
+			icon: 'list-view',
+			description: __( 'Display matches against a specific opponent.', 'wp-club-manager' ),
+			attributes: {
+				title: { type: 'string', default: '' },
+				format: { type: 'string', default: '' },
+				id: { type: 'string', default: '' },
+				limit: { type: 'string', default: '' },
+				comp: { type: 'string', default: '' },
+				season: { type: 'string', default: '' },
+				team: { type: 'string', default: '' },
+				date_range: { type: 'string', default: '' },
+				venue: { type: 'string', default: '' },
+				order: { type: 'string', default: '' },
+				show_abbr: { type: 'string', default: '0' },
+				show_thumb: { type: 'string', default: '0' },
+				show_team: { type: 'string', default: '0' },
+				show_comp: { type: 'string', default: '1' },
+				show_venue: { type: 'string', default: '1' },
+				linktext: { type: 'string', default: '' },
+				linkpage: { type: 'string', default: '' },
+			},
+			edit: makeEdit( 'wpcm/match-opponents', [
+				{ attr: 'title', label: __( 'Title', 'wp-club-manager' ) },
+				{ attr: 'format', label: __( 'Format', 'wp-club-manager' ), type: 'select', options: formatOptions },
+				{ attr: 'id', label: __( 'Club ID', 'wp-club-manager' ) },
+				{ attr: 'limit', label: __( 'Number of matches', 'wp-club-manager' ) },
+				{ attr: 'comp', label: __( 'Competition ID', 'wp-club-manager' ) },
+				{ attr: 'season', label: __( 'Season ID', 'wp-club-manager' ) },
+				{ attr: 'team', label: __( 'Team ID', 'wp-club-manager' ) },
+				{ attr: 'venue', label: __( 'Venue', 'wp-club-manager' ), type: 'select', options: venueOptions },
+				{ attr: 'date_range', label: __( 'Date Range', 'wp-club-manager' ), type: 'select', options: dateRangeOptions },
+				{ attr: 'order', label: __( 'Order', 'wp-club-manager' ), type: 'select', options: orderOptions },
+				{ attr: 'show_abbr', label: __( 'Show abbreviations', 'wp-club-manager' ), type: 'toggle' },
+				{ attr: 'show_thumb', label: __( 'Show club badges', 'wp-club-manager' ), type: 'toggle' },
+				{ attr: 'show_team', label: __( 'Show team', 'wp-club-manager' ), type: 'toggle' },
+				{ attr: 'show_comp', label: __( 'Show competition', 'wp-club-manager' ), type: 'toggle' },
+				{ attr: 'show_venue', label: __( 'Show venue', 'wp-club-manager' ), type: 'toggle' },
+				{ attr: 'linktext', label: __( 'Link text', 'wp-club-manager' ) },
+				{ attr: 'linkpage', label: __( 'Link page ID', 'wp-club-manager' ) },
+			] ),
+			save: function() { return null; },
+		} );
+	}
+} )();

--- a/includes/admin/class-wpcm-admin-dashboard-widgets.php
+++ b/includes/admin/class-wpcm-admin-dashboard-widgets.php
@@ -141,17 +141,11 @@ if ( ! class_exists( 'WPCM_Admin_Dashboard_Widgets' ) ) :
 						$side2 = $home_club;
 					}
 
+					$competition = '';
 					if ( is_array( $comps ) ) {
-						foreach ( $comps as $comp ) :
+						$comp = reset( $comps );
 
-							$comp       = reset( $comps );
-							$t_id       = $comp->term_id;
-							$comp_meta  = get_option( "taxonomy_term_$t_id" );
-							$comp_label = $comp_meta['wpcm_comp_label'];
-
-							$competition = $comp->name . '&nbsp;' . $comp_status;
-
-						endforeach;
+						$competition = $comp->name . "\xC2\xA0" . $comp_status;
 					}
 					?>
 

--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -87,17 +87,18 @@ class WPCM_Admin_Dashboard {
 
 					);
 					$args['meta_query'] = array(
-						'relation' => 'OR',
+						'relation' => 'AND',
 						array(
-							'key'   => 'wpcm_home_club',
-							'value' => $default_club,
+							'relation' => 'OR',
+							array(
+								'key'   => 'wpcm_home_club',
+								'value' => $default_club,
+							),
+							array(
+								'key'   => 'wpcm_away_club',
+								'value' => $default_club,
+							),
 						),
-						array(
-							'key'   => 'wpcm_away_club',
-							'value' => $default_club,
-						),
-					);
-					$args['meta_query'] = array(
 						array(
 							'key'   => 'wpcm_played',
 							'value' => 1,

--- a/includes/admin/class-wpcm-admin-dashboard.php
+++ b/includes/admin/class-wpcm-admin-dashboard.php
@@ -336,7 +336,9 @@ class WPCM_Admin_Dashboard {
 							}
 						}
 
+						wpcm_set_h2h_context( $comp, $season_id );
 						usort( $clubs, 'wpcm_sort_table_clubs' );
+						wpcm_clear_h2h_context();
 
 						if ( 'ASC' === $order ) {
 							$clubs = array_reverse( $clubs );
@@ -493,7 +495,9 @@ class WPCM_Admin_Dashboard {
 							}
 						}
 
+						wpcm_set_h2h_context( $comp, $season_id );
 						usort( $clubs, 'wpcm_sort_table_clubs' );
+						wpcm_clear_h2h_context();
 
 						if ( 'ASC' === $order ) {
 							$clubs = array_reverse( $clubs );

--- a/includes/admin/class-wpcm-admin-permalink-settings.php
+++ b/includes/admin/class-wpcm-admin-permalink-settings.php
@@ -28,6 +28,7 @@ if ( ! class_exists( 'WPCM_Admin_Permalink_Settings' ) ) :
 				array( 'player', __( 'Players', 'wp-club-manager' ) ),
 				array( 'staff', __( 'Staff', 'wp-club-manager' ) ),
 				array( 'match', __( 'Matches', 'wp-club-manager' ) ),
+				array( 'table', __( 'League Tables', 'wp-club-manager' ) ),
 			) );
 
 			add_action( 'admin_init', array( $this, 'settings_init' ) );

--- a/includes/admin/class-wpcm-admin-post-types.php
+++ b/includes/admin/class-wpcm-admin-post-types.php
@@ -28,7 +28,6 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 
 			add_filter( 'post_updated_messages', array( $this, 'post_updated_messages' ) );
 
-			add_filter( 'the_posts', array( $this, 'show_scheduled_matches' ) );
 			add_filter( 'wp_insert_post_data', array( $this, 'wp_insert_post_data' ), 99, 2 );
 
 			// WP List table columns. Defined here so they are always available for events such as inline editing.
@@ -217,24 +216,6 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 			);
 
 			return $messages;
-		}
-
-		/**
-		 * Show future
-		 *
-		 * @param array $posts
-		 *
-		 * @return array
-		 */
-		public function show_scheduled_matches( $posts ) {
-
-			global $wp_query, $wpdb;
-
-			if ( is_single() && 0 === $wp_query->post_count && isset( $wp_query->query_vars['wpcm_match'] ) ) {
-				$posts = $wpdb->get_results( $wp_query->request ); // phpcs:ignore
-			}
-
-			return $posts;
 		}
 
 		/**

--- a/includes/admin/class-wpcm-admin-post-types.php
+++ b/includes/admin/class-wpcm-admin-post-types.php
@@ -283,7 +283,7 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 					}
 
 					$title     = $side1 . ' ' . $separator . ' ' . $side2;
-					$post_name = sanitize_title_with_dashes( $postarr['ID'] . '-' . $title );
+					$post_name = sanitize_title( $postarr['ID'] . '-' . $title );
 
 					$data['post_title'] = $title;
 					$data['post_name']  = $post_name;
@@ -322,11 +322,12 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 					$last_name = '';
 				}
 
-				if ( $firstname || $lastname ) {
-					$title = sanitize_title_with_dashes( $first_name . '-' . $last_name );
+				if ( $first_name || $last_name ) {
+					$full_name = trim( $first_name . ' ' . $last_name );
+					$post_name = sanitize_title( $full_name );
 
-					$data['post_title'] = $first_name . ' ' . $last_name;
-					$data['post_name']  = $title;
+					$data['post_title'] = $full_name;
+					$data['post_name']  = $post_name;
 				}
 
 			endif;
@@ -344,10 +345,13 @@ if ( ! class_exists( 'WPCM_Admin_Post_Types' ) ) :
 					$lastname = sanitize_text_field( $last_name );
 				}
 
-				$title = sanitize_title_with_dashes( $firstname . '-' . $lastname );
+				$full_name = trim( $firstname . ' ' . $lastname );
+				if ( $full_name ) {
+					$post_name = sanitize_title( $full_name );
 
-				$data['post_title'] = $firstname . ' ' . $lastname;
-				$data['post_name']  = $title;
+					$data['post_title'] = $full_name;
+					$data['post_name']  = $post_name;
+				}
 
 			endif;
 

--- a/includes/admin/class-wpcm-admin-settings.php
+++ b/includes/admin/class-wpcm-admin-settings.php
@@ -51,6 +51,7 @@ if ( ! class_exists( 'WPCM_Admin_Settings' ) ) :
 				if ( in_array( 'wpcm-player-appearances/wpcm-player-appearances.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) || in_array( 'wpcm-players-gallery/wpcm-player-gallery.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) || in_array( 'wpcm-sponsors-pro/wpcm-sponsors-pro.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
 					$settings[] = include 'settings/class-wpcm-settings-licenses.php';
 				}
+				$settings[] = include 'settings/class-wpcm-settings-tools.php';
 
 				self::$settings = apply_filters( 'wpclubmanager_get_settings_pages', $settings );
 			}

--- a/includes/admin/importers/class-wpcm-match-importer.php
+++ b/includes/admin/importers/class-wpcm-match-importer.php
@@ -154,7 +154,7 @@ if ( class_exists( 'WP_Importer' ) ) {
 				);
 				$id   = wp_insert_post( $args );
 
-				$post_name = sanitize_title_with_dashes( $id . '-' . $home_club . '-' . $separator . '-' . $away_club );
+				$post_name = sanitize_title( $id . '-' . $home_club . '-' . $separator . '-' . $away_club );
 
 				wp_update_post( array(
 					'ID'         => $id,

--- a/includes/admin/importers/class-wpcm-match-importer.php
+++ b/includes/admin/importers/class-wpcm-match-importer.php
@@ -194,23 +194,19 @@ if ( class_exists( 'WP_Importer' ) ) {
 				endif;
 
 				// Update competitions
-				$comps = wpcm_array_value( $meta, 'wpcm_comp' );
-				$comp  = sanitize_title_with_dashes( $comps );
+				$comp = wpcm_array_value( $meta, 'wpcm_comp' );
 				wp_set_object_terms( $id, $comp, 'wpcm_comp', false );
 
 				// Update seasons
-				$seasons = wpcm_array_value( $meta, 'wpcm_season' );
-				$season  = sanitize_title_with_dashes( $seasons );
+				$season = wpcm_array_value( $meta, 'wpcm_season' );
 				wp_set_object_terms( $id, $season, 'wpcm_season', false );
 
 				// Update teams
-				$teams = wpcm_array_value( $meta, 'wpcm_team' );
-				$team  = sanitize_title_with_dashes( $teams );
+				$team = wpcm_array_value( $meta, 'wpcm_team' );
 				wp_set_object_terms( $id, $team, 'wpcm_team', false );
 
 				// Update venues
-				$venues = wpcm_array_value( $meta, 'wpcm_venue' );
-				$venue  = sanitize_title_with_dashes( $venues );
+				$venue = wpcm_array_value( $meta, 'wpcm_venue' );
 				wp_set_object_terms( $id, $venue, 'wpcm_venue', false );
 
 				// Update Attendance

--- a/includes/admin/importers/class-wpcm-player-importer.php
+++ b/includes/admin/importers/class-wpcm-player-importer.php
@@ -72,8 +72,8 @@ if ( class_exists( 'WP_Importer' ) ) {
 
 				$first_name = sanitize_text_field( wpcm_array_value( $meta, '_wpcm_firstname' ) );
 				$last_name  = sanitize_text_field( wpcm_array_value( $meta, '_wpcm_lastname' ) );
-				$name       = $first_name . ' ' . $last_name;
-				$post_name  = sanitize_title_with_dashes( $name );
+				$name       = trim( $first_name . ' ' . $last_name );
+				$post_name  = sanitize_title( $name );
 
 				if ( ! $name ) :
 					++$this->skipped;

--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-fixture.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-fixture.php
@@ -55,21 +55,23 @@ class WPCM_Meta_Box_Match_Fixture {
 			?>
 		</p>
 
-		<p>
-			<label><?php esc_html_e( 'Away', 'wp-club-manager' ); ?></label>
-			<?php
-			wpcm_dropdown_posts(array(
-				'name'             => 'wpcm_away_club',
-				'id'               => 'wpcm_away_club',
-				'post_type'        => 'wpcm_club',
-				'limit'            => -1,
-				'show_option_none' => __( 'Choose club', 'wp-club-manager' ),
-				'class'            => 'chosen_select',
-				'echo'             => false,
-				'selected'         => $away_club,
-			));
-			?>
-		</p>
+		<?php if ( wpcm_is_team_sport() ) : ?>
+			<p>
+				<label><?php esc_html_e( 'Away', 'wp-club-manager' ); ?></label>
+				<?php
+				wpcm_dropdown_posts(array(
+					'name'             => 'wpcm_away_club',
+					'id'               => 'wpcm_away_club',
+					'post_type'        => 'wpcm_club',
+					'limit'            => -1,
+					'show_option_none' => __( 'Choose club', 'wp-club-manager' ),
+					'class'            => 'chosen_select',
+					'echo'             => false,
+					'selected'         => $away_club,
+				));
+				?>
+			</p>
+		<?php endif; ?>
 
 		<?php
 	}
@@ -95,7 +97,7 @@ class WPCM_Meta_Box_Match_Fixture {
 			wp_set_post_terms( $home_club_id, $comp_id, 'wpcm_comp', true );
 			wp_set_post_terms( $home_club_id, $season_id, 'wpcm_season', true );
 		}
-		if ( isset( $away_club_id ) ) {
+		if ( isset( $away_club_id ) && wpcm_is_team_sport() ) {
 			update_post_meta( $post_id, 'wpcm_away_club', $away_club_id );
 			wp_set_post_terms( $away_club_id, $comp_id, 'wpcm_comp', true );
 			wp_set_post_terms( $away_club_id, $season_id, 'wpcm_season', true );

--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-table-stats.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-table-stats.php
@@ -117,7 +117,9 @@ class WPCM_Meta_Box_Table_Stats {
 			}
 		}
 
+		wpcm_set_h2h_context( $comp, $season );
 		usort( $clubs, 'wpcm_sort_table_clubs' );
+		wpcm_clear_h2h_context();
 
 		if ( 'ASC' === $order ) {
 			$clubs = array_reverse( $clubs );

--- a/includes/admin/settings/class-wpcm-settings-standings.php
+++ b/includes/admin/settings/class-wpcm-settings-standings.php
@@ -138,7 +138,8 @@ if ( ! class_exists( 'WPCM_Settings_Standings' ) ) :
 			);
 
 			$stats_names = wpcm_get_preset_labels( 'standings', 'name' );
-			$options = $stats_names;
+			$options         = $stats_names;
+			$options['h2h']  = __( 'Head-to-Head Record', 'wp-club-manager' );
 
 			$settings[] = array(
 				'title'    => __( 'Priority 1', 'wp-club-manager' ),

--- a/includes/admin/settings/class-wpcm-settings-tools.php
+++ b/includes/admin/settings/class-wpcm-settings-tools.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * WPClubManager Tools Settings (Export/Import)
+ *
+ * @author      ClubPress
+ * @category    Admin
+ * @package     WPClubManager/Admin
+ * @version     2.4.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'WPCM_Settings_Tools' ) ) :
+
+	/**
+	 * WPCM_Settings_Tools
+	 */
+	class WPCM_Settings_Tools extends WPCM_Settings_Page {
+
+		/**
+		 * Options that should not be exported or imported.
+		 *
+		 * @var array
+		 */
+		private static $excluded_options = array(
+			'wpclubmanager_version',
+			'wpclubmanager_installed',
+			'wpcm_version_upgraded_from',
+			'wpclubmanager_admin_footer_text_rated',
+			'wpcm_transient_keys',
+			'wpclubmanager_admin_notices',
+			'wpclubmanager_meta_box_errors',
+		);
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id    = 'tools';
+			$this->label = __( 'Tools', 'wp-club-manager' );
+
+			add_filter( 'wpclubmanager_settings_tabs_array', array( $this, 'add_settings_page' ), 99 );
+			add_action( 'wpclubmanager_settings_' . $this->id, array( $this, 'output' ) );
+			add_action( 'wpclubmanager_settings_save_' . $this->id, array( $this, 'save' ) );
+			add_action( 'admin_post_wpcm_export_settings', array( $this, 'handle_export' ) );
+		}
+
+		/**
+		 * Get all WPCM option names from the database.
+		 *
+		 * @return array
+		 */
+		private static function get_wpcm_option_names() {
+			global $wpdb;
+
+			$results = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+					$wpdb->esc_like( 'wpcm_' ) . '%',
+					$wpdb->esc_like( 'wpclubmanager_' ) . '%'
+				)
+			);
+
+			return is_array( $results ) ? $results : array();
+		}
+
+		/**
+		 * Check if an option name is a valid WPCM setting.
+		 *
+		 * @param string $option_name Option name to check.
+		 * @return bool
+		 */
+		private static function is_valid_option( $option_name ) {
+			if ( in_array( $option_name, self::$excluded_options, true ) ) {
+				return false;
+			}
+
+			return ( strpos( $option_name, 'wpcm_' ) === 0 || strpos( $option_name, 'wpclubmanager_' ) === 0 );
+		}
+
+		/**
+		 * Sanitize a value for import.
+		 *
+		 * @param mixed $value Value to clean.
+		 * @return mixed
+		 */
+		private static function clean_value( $value ) {
+			if ( is_array( $value ) ) {
+				return array_map( array( __CLASS__, 'clean_value' ), $value );
+			}
+
+			return is_string( $value ) ? wpcm_clean( $value ) : $value;
+		}
+
+		/**
+		 * Get export data as an associative array.
+		 *
+		 * @return array
+		 */
+		public static function get_export_data() {
+			$option_names = self::get_wpcm_option_names();
+			$data         = array();
+
+			foreach ( $option_names as $name ) {
+				if ( self::is_valid_option( $name ) ) {
+					$data[ $name ] = get_option( $name );
+				}
+			}
+
+			ksort( $data );
+
+			return $data;
+		}
+
+		/**
+		 * Validate import JSON string.
+		 *
+		 * @param string $json JSON string to validate.
+		 * @return array|WP_Error Decoded data array on success, WP_Error on failure.
+		 */
+		public static function validate_import_json( $json ) {
+			$data = json_decode( $json, true );
+
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
+				return new WP_Error(
+					'invalid_json',
+					__( 'The uploaded file does not contain valid JSON.', 'wp-club-manager' )
+				);
+			}
+
+			if ( ! is_array( $data ) || empty( $data ) ) {
+				return new WP_Error(
+					'invalid_format',
+					__( 'The uploaded file does not contain valid settings data.', 'wp-club-manager' )
+				);
+			}
+
+			return $data;
+		}
+
+		/**
+		 * Import settings from an associative array.
+		 *
+		 * @param array $data Settings data to import.
+		 * @return bool True on success, false if no valid settings were imported.
+		 */
+		public static function import_settings( $data ) {
+			if ( empty( $data ) ) {
+				return false;
+			}
+
+			$updated = 0;
+
+			foreach ( $data as $name => $value ) {
+				if ( self::is_valid_option( $name ) ) {
+					$value = self::clean_value( $value );
+					update_option( $name, $value );
+					++$updated;
+				}
+			}
+
+			return $updated > 0;
+		}
+
+		/**
+		 * Handle the export action via admin-post.php.
+		 */
+		public function handle_export() {
+			check_admin_referer( 'wpcm-export-settings' );
+
+			if ( ! current_user_can( 'manage_wpclubmanager' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You do not have permission to export settings.', 'wp-club-manager' ) );
+			}
+
+			$data     = self::get_export_data();
+			$filename = 'wpcm-settings-' . gmdate( 'Y-m-d' ) . '.json';
+
+			nocache_headers();
+			header( 'Content-Type: application/json; charset=utf-8' );
+			header( 'Content-Disposition: attachment; filename=' . $filename );
+			header( 'Expires: 0' );
+
+			echo wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
+			exit;
+		}
+
+		/**
+		 * Save / process import.
+		 */
+		public function save() {
+			$nonce = filter_input( INPUT_POST, '_wpnonce', FILTER_UNSAFE_RAW );
+			if ( empty( $nonce ) || ! wp_verify_nonce( sanitize_text_field( $nonce ), 'wpclubmanager-settings' ) ) {
+				return;
+			}
+
+			if ( ! current_user_can( 'manage_wpclubmanager' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				return;
+			}
+
+			if ( empty( $_FILES['wpcm_import_file'] ) || empty( $_FILES['wpcm_import_file']['tmp_name'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+				WPCM_Admin_Settings::add_error( __( 'Please select a JSON file to import.', 'wp-club-manager' ) );
+				return;
+			}
+
+			$file = $_FILES['wpcm_import_file']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+
+			if ( ! empty( $file['error'] ) ) {
+				WPCM_Admin_Settings::add_error( __( 'There was an error uploading the file. Please try again.', 'wp-club-manager' ) );
+				return;
+			}
+
+			$tmp_name = wp_unslash( $file['tmp_name'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+			if ( ! is_uploaded_file( $tmp_name ) ) {
+				WPCM_Admin_Settings::add_error( __( 'The uploaded file could not be read. Please try again.', 'wp-club-manager' ) );
+				return;
+			}
+
+			$json = file_get_contents( $tmp_name ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+			if ( false === $json ) {
+				WPCM_Admin_Settings::add_error( __( 'The uploaded file could not be read. Please try again.', 'wp-club-manager' ) );
+				return;
+			}
+
+			$data = self::validate_import_json( $json );
+
+			if ( is_wp_error( $data ) ) {
+				WPCM_Admin_Settings::add_error( $data->get_error_message() );
+				return;
+			}
+
+			$result = self::import_settings( $data );
+
+			if ( $result ) {
+				WPCM_Admin_Settings::add_message( __( 'Settings imported successfully.', 'wp-club-manager' ) );
+			} else {
+				WPCM_Admin_Settings::add_error( __( 'No valid settings found in the uploaded file.', 'wp-club-manager' ) );
+			}
+		}
+
+		/**
+		 * Get settings array (empty — this tab uses custom output).
+		 *
+		 * @return array
+		 */
+		public function get_settings() {
+			return array();
+		}
+
+		/**
+		 * Output the tools page.
+		 */
+		public function output() {
+			$GLOBALS['hide_save_button'] = true;
+
+			$export_url = wp_nonce_url(
+				admin_url( 'admin-post.php?action=wpcm_export_settings' ),
+				'wpcm-export-settings'
+			);
+			?>
+			<div class="stuffbox">
+				<h3><?php esc_html_e( 'Export Settings', 'wp-club-manager' ); ?></h3>
+				<div class="inside">
+					<p><?php esc_html_e( 'Export your WP Club Manager settings as a JSON file. This can be used to transfer your settings to another site.', 'wp-club-manager' ); ?></p>
+					<p>
+						<a href="<?php echo esc_url( $export_url ); ?>" class="button">
+							<?php esc_html_e( 'Export Settings', 'wp-club-manager' ); ?>
+						</a>
+					</p>
+				</div>
+			</div>
+
+			<div class="stuffbox">
+				<h3><?php esc_html_e( 'Import Settings', 'wp-club-manager' ); ?></h3>
+				<div class="inside">
+					<p><?php esc_html_e( 'Import WP Club Manager settings from a previously exported JSON file. This will overwrite your current settings.', 'wp-club-manager' ); ?></p>
+					<table class="form-table">
+						<tr>
+							<th scope="row" class="titledesc">
+								<label for="wpcm_import_file"><?php esc_html_e( 'Settings File', 'wp-club-manager' ); ?></label>
+							</th>
+							<td class="forminp">
+								<input type="file" name="wpcm_import_file" id="wpcm_import_file" accept=".json" />
+								<span class="description"><?php esc_html_e( 'Upload a .json file previously exported from WP Club Manager.', 'wp-club-manager' ); ?></span>
+							</td>
+						</tr>
+					</table>
+					<p class="submit">
+						<input name="save" class="button-primary" type="submit" value="<?php esc_html_e( 'Import Settings', 'wp-club-manager' ); ?>" />
+					</p>
+				</div>
+			</div>
+			<?php
+		}
+	}
+
+endif;
+
+return new WPCM_Settings_Tools();

--- a/includes/class-wp-club-manager.php
+++ b/includes/class-wp-club-manager.php
@@ -111,6 +111,7 @@ if ( ! class_exists( 'WPClubManager' ) ) :
 			add_action( 'after_setup_theme', array( $this, 'wpcm_template_debug_mode' ), 20 );
 			add_action( 'init', array( $this, 'init' ), 0 );
 			add_action( 'init', array( 'WPCM_Shortcodes', 'init' ) );
+			WPCM_Blocks::init();
 			add_action( 'tgmpa_register', array( $this, 'wp_club_manager_register_required_plugins' ) );
 
 			do_action( 'wpclubmanager_loaded' );
@@ -372,15 +373,7 @@ if ( ! class_exists( 'WPClubManager' ) ) :
 		 * @since 2.1.11
 		 */
 		public function wp_club_manager_register_required_plugins() {
-			$plugins = array(
-
-				array(
-					'name'     => 'Classic Editor',
-					'slug'     => 'classic-editor',
-					'required' => true,
-				),
-
-			);
+			$plugins = array();
 
 			$config = array(
 				'id'           => 'wp-club-manager',

--- a/includes/class-wp-club-manager.php
+++ b/includes/class-wp-club-manager.php
@@ -112,6 +112,7 @@ if ( ! class_exists( 'WPClubManager' ) ) :
 			add_action( 'init', array( $this, 'init' ), 0 );
 			add_action( 'init', array( 'WPCM_Shortcodes', 'init' ) );
 			WPCM_Blocks::init();
+			WPCM_ICal_Feed::init();
 			add_action( 'tgmpa_register', array( $this, 'wp_club_manager_register_required_plugins' ) );
 
 			do_action( 'wpclubmanager_loaded' );

--- a/includes/class-wpcm-blocks.php
+++ b/includes/class-wpcm-blocks.php
@@ -1,0 +1,727 @@
+<?php
+/**
+ * WPCM_Blocks class.
+ *
+ * Registers Gutenberg blocks for all WPCM shortcodes.
+ * Each block uses ServerSideRender in the editor and delegates
+ * to the existing shortcode output classes for rendering.
+ *
+ * @class       WPCM_Blocks
+ * @version     2.4.0
+ * @package     WPClubManager/Classes
+ * @category    Class
+ * @author      ClubPress
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WPCM_Blocks
+ */
+class WPCM_Blocks {
+
+	/**
+	 * Initialise block registration hooks.
+	 */
+	public static function init() {
+		if ( ! function_exists( 'register_block_type' ) ) {
+			return;
+		}
+
+		add_action( 'init', array( __CLASS__, 'register_blocks' ) );
+
+		add_filter( 'block_categories_all', array( __CLASS__, 'register_category' ), 10, 2 );
+		add_filter( 'block_categories', array( __CLASS__, 'register_category' ), 10, 2 );
+	}
+
+	/**
+	 * Register the WP Club Manager block category.
+	 *
+	 * @param array[] $categories Array of block categories.
+	 * @param mixed   $context    Block editor context (WP_Post or WP_Block_Editor_Context).
+	 * @return array[]
+	 */
+	public static function register_category( $categories, $context = null ) {
+		return array_merge(
+			$categories,
+			array(
+				array(
+					'slug'  => 'wp-club-manager',
+					'title' => __( 'WP Club Manager', 'wp-club-manager' ),
+					'icon'  => 'awards',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register the editor script and all blocks.
+	 */
+	public static function register_blocks() {
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'wpcm/match-list' ) ) {
+			return;
+		}
+
+		wp_register_script(
+			'wpcm-blocks-editor',
+			plugins_url( 'assets/js/blocks/wpcm-blocks-editor.js', WPCM_PLUGIN_FILE ),
+			array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-editor', 'wp-components', 'wp-server-side-render', 'wp-i18n' ),
+			WPCM_VERSION,
+			true
+		);
+
+		wp_set_script_translations( 'wpcm-blocks-editor', 'wp-club-manager', plugin_dir_path( WPCM_PLUGIN_FILE ) . 'languages' );
+
+		$is_club_mode = function_exists( 'is_club_mode' ) && is_club_mode();
+
+		wp_localize_script(
+			'wpcm-blocks-editor',
+			'wpcmBlocksConfig',
+			array(
+				'clubMode' => $is_club_mode,
+			)
+		);
+
+		self::register_match_list();
+		self::register_player_list();
+		self::register_player_gallery();
+		self::register_staff_list();
+		self::register_staff_gallery();
+		self::register_league_table();
+		self::register_map_venue();
+
+		if ( function_exists( 'is_club_mode' ) && is_club_mode() ) {
+			self::register_match_opponents();
+		}
+	}
+
+	/**
+	 * Register the Match List block.
+	 */
+	private static function register_match_list() {
+		register_block_type(
+			'wpcm/match-list',
+			array(
+				'title'           => __( 'Match List', 'wp-club-manager' ),
+				'category'        => 'wp-club-manager',
+				'editor_script'   => 'wpcm-blocks-editor',
+				'render_callback' => array( __CLASS__, 'render_match_list' ),
+				'attributes'      => array(
+					'title'      => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'format'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'limit'      => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'comp'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'season'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'team'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'venue'      => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'date_range' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'order'      => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'show_abbr'  => array(
+						'type'    => 'string',
+						'default' => '0',
+					),
+					'show_thumb' => array(
+						'type'    => 'string',
+						'default' => '0',
+					),
+					'show_comp'  => array(
+						'type'    => 'string',
+						'default' => '1',
+					),
+					'show_team'  => array(
+						'type'    => 'string',
+						'default' => '0',
+					),
+					'show_venue' => array(
+						'type'    => 'string',
+						'default' => '0',
+					),
+					'linktext'   => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'linkpage'   => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register the Player List block.
+	 */
+	private static function register_player_list() {
+		register_block_type(
+			'wpcm/player-list',
+			array(
+				'title'           => __( 'Player List', 'wp-club-manager' ),
+				'category'        => 'wp-club-manager',
+				'editor_script'   => 'wpcm-blocks-editor',
+				'render_callback' => array( __CLASS__, 'render_player_list' ),
+				'attributes'      => array(
+					'id'          => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'limit'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'position'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'orderby'     => array(
+						'type'    => 'string',
+						'default' => 'number',
+					),
+					'order'       => array(
+						'type'    => 'string',
+						'default' => 'ASC',
+					),
+					'linktext'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'linkpage'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'columns'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'title'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'name_format' => array(
+						'type'    => 'string',
+						'default' => 'full',
+					),
+					'type'        => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register the Player Gallery block.
+	 */
+	private static function register_player_gallery() {
+		register_block_type(
+			'wpcm/player-gallery',
+			array(
+				'title'           => __( 'Player Gallery', 'wp-club-manager' ),
+				'category'        => 'wp-club-manager',
+				'editor_script'   => 'wpcm-blocks-editor',
+				'render_callback' => array( __CLASS__, 'render_player_gallery' ),
+				'attributes'      => array(
+					'id'          => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'title'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'limit'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'position'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'orderby'     => array(
+						'type'    => 'string',
+						'default' => 'number',
+					),
+					'order'       => array(
+						'type'    => 'string',
+						'default' => 'ASC',
+					),
+					'columns'     => array(
+						'type'    => 'string',
+						'default' => '3',
+					),
+					'linktext'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'linkpage'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'name_format' => array(
+						'type'    => 'string',
+						'default' => 'full',
+					),
+					'type'        => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register the Staff List block.
+	 */
+	private static function register_staff_list() {
+		register_block_type(
+			'wpcm/staff-list',
+			array(
+				'title'           => __( 'Staff List', 'wp-club-manager' ),
+				'category'        => 'wp-club-manager',
+				'editor_script'   => 'wpcm-blocks-editor',
+				'render_callback' => array( __CLASS__, 'render_staff_list' ),
+				'attributes'      => array(
+					'id'          => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'limit'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'job'         => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'orderby'     => array(
+						'type'    => 'string',
+						'default' => 'name',
+					),
+					'order'       => array(
+						'type'    => 'string',
+						'default' => 'ASC',
+					),
+					'linktext'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'linkpage'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'columns'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'title'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'name_format' => array(
+						'type'    => 'string',
+						'default' => 'full',
+					),
+					'type'        => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register the Staff Gallery block.
+	 */
+	private static function register_staff_gallery() {
+		register_block_type(
+			'wpcm/staff-gallery',
+			array(
+				'title'           => __( 'Staff Gallery', 'wp-club-manager' ),
+				'category'        => 'wp-club-manager',
+				'editor_script'   => 'wpcm-blocks-editor',
+				'render_callback' => array( __CLASS__, 'render_staff_gallery' ),
+				'attributes'      => array(
+					'id'          => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'title'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'limit'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'jobs'        => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'orderby'     => array(
+						'type'    => 'string',
+						'default' => 'name',
+					),
+					'order'       => array(
+						'type'    => 'string',
+						'default' => 'ASC',
+					),
+					'columns'     => array(
+						'type'    => 'string',
+						'default' => '3',
+					),
+					'linktext'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'linkpage'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'name_format' => array(
+						'type'    => 'string',
+						'default' => 'full',
+					),
+					'type'        => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register the League Table block.
+	 */
+	private static function register_league_table() {
+		register_block_type(
+			'wpcm/league-table',
+			array(
+				'title'           => __( 'League Table', 'wp-club-manager' ),
+				'category'        => 'wp-club-manager',
+				'editor_script'   => 'wpcm-blocks-editor',
+				'render_callback' => array( __CLASS__, 'render_league_table' ),
+				'attributes'      => array(
+					'id'        => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'title'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'limit'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'focus'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'abbr'      => array(
+						'type'    => 'string',
+						'default' => '0',
+					),
+					'thumb'     => array(
+						'type'    => 'string',
+						'default' => '1',
+					),
+					'link_club' => array(
+						'type'    => 'string',
+						'default' => '1',
+					),
+					'type'      => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'notes'     => array(
+						'type'    => 'string',
+						'default' => '0',
+					),
+					'columns'   => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'linktext'  => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'linkpage'  => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register the Map Venue block.
+	 */
+	private static function register_map_venue() {
+		register_block_type(
+			'wpcm/map-venue',
+			array(
+				'title'           => __( 'Map Venue', 'wp-club-manager' ),
+				'category'        => 'wp-club-manager',
+				'editor_script'   => 'wpcm-blocks-editor',
+				'render_callback' => array( __CLASS__, 'render_map_venue' ),
+				'attributes'      => array(
+					'id'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'title'  => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'width'  => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'height' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register the Match Opponents block (club mode only).
+	 */
+	private static function register_match_opponents() {
+		register_block_type(
+			'wpcm/match-opponents',
+			array(
+				'title'           => __( 'Match Opponents', 'wp-club-manager' ),
+				'category'        => 'wp-club-manager',
+				'editor_script'   => 'wpcm-blocks-editor',
+				'render_callback' => array( __CLASS__, 'render_match_opponents' ),
+				'attributes'      => array(
+					'title'      => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'format'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'id'         => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'limit'      => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'comp'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'season'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'team'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'date_range' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'venue'      => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'order'      => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'show_abbr'  => array(
+						'type'    => 'string',
+						'default' => '0',
+					),
+					'show_thumb' => array(
+						'type'    => 'string',
+						'default' => '0',
+					),
+					'show_team'  => array(
+						'type'    => 'string',
+						'default' => '0',
+					),
+					'show_comp'  => array(
+						'type'    => 'string',
+						'default' => '1',
+					),
+					'show_venue' => array(
+						'type'    => 'string',
+						'default' => '1',
+					),
+					'linktext'   => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'linkpage'   => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Render the Match List block.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @param mixed  $block      WP_Block instance or null.
+	 * @return string
+	 */
+	public static function render_match_list( $attributes, $content = '', $block = null ) {
+		return WPCM_Shortcodes::shortcode_wrapper(
+			array( 'WPCM_Shortcode_Match_List', 'output' ),
+			$attributes
+		);
+	}
+
+	/**
+	 * Render the Player List block.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @param mixed  $block      WP_Block instance or null.
+	 * @return string
+	 */
+	public static function render_player_list( $attributes, $content = '', $block = null ) {
+		return WPCM_Shortcodes::shortcode_wrapper(
+			array( 'WPCM_Shortcode_Player_List', 'output' ),
+			$attributes
+		);
+	}
+
+	/**
+	 * Render the Player Gallery block.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @param mixed  $block      WP_Block instance or null.
+	 * @return string
+	 */
+	public static function render_player_gallery( $attributes, $content = '', $block = null ) {
+		return WPCM_Shortcodes::shortcode_wrapper(
+			array( 'WPCM_Shortcode_Player_Gallery', 'output' ),
+			$attributes
+		);
+	}
+
+	/**
+	 * Render the Staff List block.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @param mixed  $block      WP_Block instance or null.
+	 * @return string
+	 */
+	public static function render_staff_list( $attributes, $content = '', $block = null ) {
+		return WPCM_Shortcodes::shortcode_wrapper(
+			array( 'WPCM_Shortcode_Staff_List', 'output' ),
+			$attributes
+		);
+	}
+
+	/**
+	 * Render the Staff Gallery block.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @param mixed  $block      WP_Block instance or null.
+	 * @return string
+	 */
+	public static function render_staff_gallery( $attributes, $content = '', $block = null ) {
+		return WPCM_Shortcodes::shortcode_wrapper(
+			array( 'WPCM_Shortcode_Staff_Gallery', 'output' ),
+			$attributes
+		);
+	}
+
+	/**
+	 * Render the League Table block.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @param mixed  $block      WP_Block instance or null.
+	 * @return string
+	 */
+	public static function render_league_table( $attributes, $content = '', $block = null ) {
+		return WPCM_Shortcodes::shortcode_wrapper(
+			array( 'WPCM_Shortcode_League_Table', 'output' ),
+			$attributes
+		);
+	}
+
+	/**
+	 * Render the Map Venue block.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @param mixed  $block      WP_Block instance or null.
+	 * @return string
+	 */
+	public static function render_map_venue( $attributes, $content = '', $block = null ) {
+		return WPCM_Shortcodes::shortcode_wrapper(
+			array( 'WPCM_Shortcode_Map_Venue', 'output' ),
+			$attributes
+		);
+	}
+
+	/**
+	 * Render the Match Opponents block.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @param mixed  $block      WP_Block instance or null.
+	 * @return string
+	 */
+	public static function render_match_opponents( $attributes, $content = '', $block = null ) {
+		return WPCM_Shortcodes::shortcode_wrapper(
+			array( 'WPCM_Shortcode_Match_Opponents', 'output' ),
+			$attributes
+		);
+	}
+}

--- a/includes/class-wpcm-ical-feed.php
+++ b/includes/class-wpcm-ical-feed.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * WPCM iCal Feed
+ *
+ * Generates an iCalendar (.ics) feed of matches for subscribing
+ * to fixtures in external calendar applications.
+ *
+ * @class       WPCM_ICal_Feed
+ * @version     2.4.0
+ * @package     WPClubManager/Classes
+ * @category    Class
+ * @author      ClubPress
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * WPCM_ICal_Feed
+ */
+class WPCM_ICal_Feed {
+
+	/**
+	 * Hook into WordPress.
+	 */
+	public static function init() {
+		add_action( 'init', array( __CLASS__, 'add_feed' ) );
+	}
+
+	/**
+	 * Register the iCal feed endpoint.
+	 */
+	public static function add_feed() {
+		add_feed( 'wpcm_ical', array( __CLASS__, 'render_feed' ) );
+	}
+
+	/**
+	 * Render the iCal feed response.
+	 */
+	public static function render_feed() {
+		$comp   = isset( $_GET['comp'] ) ? absint( $_GET['comp'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification
+		$season = isset( $_GET['season'] ) ? absint( $_GET['season'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification
+		$team   = isset( $_GET['team'] ) ? absint( $_GET['team'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification
+
+		$args = array_filter( array(
+			'comp'   => $comp,
+			'season' => $season,
+			'team'   => $team,
+		) );
+
+		$feed = new self();
+
+		header( 'Content-Type: text/calendar; charset=utf-8' );
+		header( 'Content-Disposition: inline; filename="matches.ics"' );
+
+		echo $feed->generate( $args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		exit;
+	}
+
+	/**
+	 * Get the URL for the iCal feed.
+	 *
+	 * @param array $args Optional query parameters (comp, season, team).
+	 * @return string
+	 */
+	public function get_feed_url( $args = array() ) {
+		$url = get_feed_link( 'wpcm_ical' );
+
+		if ( ! empty( $args ) ) {
+			$url = add_query_arg( $args, $url );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Generate iCal output.
+	 *
+	 * @param array $args Optional filters: comp, season, team.
+	 * @return string iCalendar formatted string.
+	 */
+	public function generate( $args = array() ) {
+		$comp   = isset( $args['comp'] ) ? $args['comp'] : null;
+		$season = isset( $args['season'] ) ? $args['season'] : null;
+		$team   = isset( $args['team'] ) ? $args['team'] : null;
+
+		// Limit feed to 6 months past and 12 months future to avoid large responses.
+		// Use current_time so bounds align with post_date (site-local time).
+		$date_start = wp_date( 'Y-m-d', strtotime( '-6 months' ) );
+		$date_end   = wp_date( 'Y-m-d', strtotime( '+12 months' ) );
+
+		$query_args = array(
+			'tax_query'      => array(), // phpcs:ignore
+			'order'          => 'ASC',
+			'orderby'        => 'post_date',
+			'post_type'      => 'wpcm_match',
+			'post_status'    => array( 'publish', 'future' ),
+			'posts_per_page' => -1,
+			'date_query'     => array(
+				array(
+					'after'     => $date_start,
+					'before'    => $date_end,
+					'inclusive' => true,
+				),
+			),
+		);
+
+		if ( is_club_mode() ) {
+			$club                         = get_default_club();
+			$query_args['meta_query'] = array( // phpcs:ignore
+				'relation' => 'OR',
+				array(
+					'key'   => 'wpcm_home_club',
+					'value' => $club,
+				),
+				array(
+					'key'   => 'wpcm_away_club',
+					'value' => $club,
+				),
+			);
+		}
+
+		if ( isset( $comp ) ) {
+			$query_args['tax_query'][] = array(
+				'taxonomy' => 'wpcm_comp',
+				'terms'    => $comp,
+				'field'    => 'term_id',
+			);
+		}
+		if ( isset( $season ) ) {
+			$query_args['tax_query'][] = array(
+				'taxonomy' => 'wpcm_season',
+				'terms'    => $season,
+				'field'    => 'term_id',
+			);
+		}
+		if ( isset( $team ) ) {
+			$query_args['tax_query'][] = array(
+				'taxonomy' => 'wpcm_team',
+				'terms'    => $team,
+				'field'    => 'term_id',
+			);
+		}
+
+		$matches = get_posts( $query_args );
+
+		$lines   = array();
+		$lines[] = 'BEGIN:VCALENDAR';
+		$lines[] = 'VERSION:2.0';
+		$lines[] = 'PRODID:-//WP Club Manager//NONSGML v' . WPCM_VERSION . '//EN';
+		$lines[] = 'CALSCALE:GREGORIAN';
+		$lines[] = 'METHOD:PUBLISH';
+		/* translators: %s: site name */
+		$lines[] = 'X-WR-CALNAME:' . $this->escape_ical_text( sprintf( __( '%s Matches', 'wp-club-manager' ), get_bloginfo( 'name' ) ) );
+
+		foreach ( $matches as $match ) {
+			$lines = array_merge( $lines, $this->build_vevent( $match ) );
+		}
+
+		$lines[] = 'END:VCALENDAR';
+
+		wp_reset_postdata();
+
+		$folded = array_map( array( $this, 'fold_line' ), $lines );
+
+		return implode( "\r\n", $folded ) . "\r\n";
+	}
+
+	/**
+	 * Build a VEVENT block for a match.
+	 *
+	 * @param WP_Post $match Match post object.
+	 * @return array Lines for the VEVENT.
+	 */
+	private function build_vevent( $match ) {
+		$timestamp  = get_post_time( 'U', true, $match );
+		$dtstart    = gmdate( 'Ymd\THis\Z', $timestamp );
+		// Default match duration: 2 hours.
+		$dtend      = gmdate( 'Ymd\THis\Z', $timestamp + 7200 );
+		$dtstamp    = gmdate( 'Ymd\THis\Z' );
+		$uid        = 'wpcm-match-' . $match->ID . '@' . wp_parse_url( home_url(), PHP_URL_HOST );
+		$url        = get_post_permalink( $match->ID, false, true );
+		$played     = get_post_meta( $match->ID, 'wpcm_played', true );
+
+		$sides   = wpcm_get_match_clubs( $match->ID, false );
+		$summary = $sides[0] . ' vs ' . $sides[1];
+
+		$description_parts = array();
+		$comp_data         = wpcm_get_match_comp( $match->ID );
+		if ( ! empty( $comp_data[0] ) ) {
+			$description_parts[] = $comp_data[0];
+		}
+		if ( $played ) {
+			$result              = wpcm_get_match_result( $match->ID );
+			/* translators: %s: match result score */
+			$description_parts[] = sprintf( __( 'Result: %s', 'wp-club-manager' ), $result[0] );
+		}
+
+		$venue_data = wpcm_get_match_venue( $match->ID );
+		$location   = '';
+		if ( isset( $venue_data['name'] ) && ! empty( $venue_data['name'] ) ) {
+			$location = $venue_data['name'];
+			if ( ! empty( $venue_data['address'] ) ) {
+				$location .= ', ' . $venue_data['address'];
+			}
+		}
+
+		$lines   = array();
+		$lines[] = 'BEGIN:VEVENT';
+		$lines[] = 'UID:' . $uid;
+		$lines[] = 'DTSTAMP:' . $dtstamp;
+		$lines[] = 'DTSTART:' . $dtstart;
+		$lines[] = 'DTEND:' . $dtend;
+		$lines[] = 'SUMMARY:' . $this->escape_ical_text( $summary );
+
+		if ( ! empty( $description_parts ) ) {
+			$lines[] = 'DESCRIPTION:' . $this->escape_ical_text( implode( "\n", $description_parts ) );
+		}
+
+		if ( '' !== $location ) {
+			$lines[] = 'LOCATION:' . $this->escape_ical_text( $location );
+		}
+
+		$lines[] = 'URL:' . $url;
+		$lines[] = 'STATUS:CONFIRMED';
+		$lines[] = 'END:VEVENT';
+
+		return $lines;
+	}
+
+	/**
+	 * Escape text for iCalendar format (RFC 5545).
+	 *
+	 * @param string $text Text to escape.
+	 * @return string Escaped text.
+	 */
+	private function escape_ical_text( $text ) {
+		$text = str_replace( '\\', '\\\\', $text );
+		$text = str_replace( "\r\n", '\n', $text );
+		$text = str_replace( "\r", '\n', $text );
+		$text = str_replace( "\n", '\n', $text );
+		$text = str_replace( ',', '\,', $text );
+		$text = str_replace( ';', '\;', $text );
+		return $text;
+	}
+
+	/**
+	 * Fold a single iCal line at 75 octets per RFC 5545.
+	 *
+	 * @param string $line The line to fold.
+	 * @return string Folded line.
+	 */
+	private function fold_line( $line ) {
+		if ( strlen( $line ) <= 75 ) {
+			return $line;
+		}
+
+		if ( function_exists( 'mb_strcut' ) ) {
+			$folded = mb_strcut( $line, 0, 75, 'UTF-8' );
+			$rest   = mb_strcut( $line, strlen( $folded ), null, 'UTF-8' );
+
+			while ( '' !== $rest ) {
+				$chunk   = mb_strcut( $rest, 0, 74, 'UTF-8' );
+				$folded .= "\r\n " . $chunk;
+				$rest    = mb_strcut( $rest, strlen( $chunk ), null, 'UTF-8' );
+			}
+
+			return $folded;
+		}
+
+		// Fallback: fold at 75/74 octets but avoid splitting UTF-8 multibyte sequences.
+		$folded = '';
+		$first  = true;
+		while ( '' !== $line ) {
+			$max   = $first ? 75 : 74;
+			$first = false;
+
+			if ( strlen( $line ) <= $max ) {
+				$folded .= $line;
+				break;
+			}
+
+			$cut = $max;
+			// Walk back if we're in the middle of a UTF-8 multibyte sequence (continuation byte 10xxxxxx).
+			while ( $cut > 0 && ( ord( $line[ $cut ] ) & 0xC0 ) === 0x80 ) {
+				--$cut;
+			}
+
+			$folded .= substr( $line, 0, $cut ) . "\r\n ";
+			$line    = substr( $line, $cut );
+		}
+
+		return $folded;
+	}
+}

--- a/includes/class-wpcm-post-types.php
+++ b/includes/class-wpcm-post-types.php
@@ -400,10 +400,13 @@ class WPCM_Post_Types {
 			)
 		);
 
+		$permalink       = get_option( 'wpclubmanager_table_slug' );
+		$table_permalink = empty( $permalink ) ? _x( 'table', 'slug', 'wp-club-manager' ) : $permalink;
+
 		register_post_type( 'wpcm_table',
 			apply_filters( 'wpclubmanager_register_post_type_table',
 				array(
-					'labels'            => array(
+					'labels'              => array(
 						'name'               => __( 'League Tables', 'wp-club-manager' ),
 						'singular_name'      => __( 'League Table', 'wp-club-manager' ),
 						'add_new'            => __( 'Add New', 'wp-club-manager' ),
@@ -418,18 +421,22 @@ class WPCM_Post_Types {
 						'parent_item_colon'  => __( 'Parent League Table:', 'wp-club-manager' ),
 						'menu_name'          => __( 'League Tables', 'wp-club-manager' ),
 					),
-					'hierarchical'      => false,
-					'supports'          => array( 'title' ),
-					'public'            => false,
-					'show_ui'           => true,
-					'show_in_menu'      => false,
-					'query_var'         => false,
-					'rewrite'           => false,
-					'capability_type'   => 'wpcm_table',
-					'map_meta_cap'      => true,
-					'show_in_admin_bar' => true,
-					'taxonomies'        => array( 'wpcm_team', 'wpcm_season', 'wpcm_comp' ),
-					'show_in_rest'      => true,
+					'hierarchical'        => false,
+					'supports'            => array( 'title' ),
+					'public'              => true,
+					'show_ui'             => true,
+					'show_in_menu'        => false,
+					'publicly_queryable'  => true,
+					'exclude_from_search' => true,
+					'has_archive'         => false,
+					'query_var'           => true,
+					'can_export'          => true,
+					'rewrite'             => $table_permalink ? array( 'slug' => untrailingslashit( $table_permalink ) ) : false,
+					'capability_type'     => 'wpcm_table',
+					'map_meta_cap'        => true,
+					'show_in_admin_bar'   => true,
+					'taxonomies'          => array( 'wpcm_team', 'wpcm_season', 'wpcm_comp' ),
+					'show_in_rest'        => true,
 				)
 			)
 		);

--- a/includes/class-wpcm-post-types.php
+++ b/includes/class-wpcm-post-types.php
@@ -28,7 +28,7 @@ class WPCM_Post_Types {
 		add_action( 'init', array( __CLASS__, 'register_taxonomies' ), 5 );
 		add_action( 'init', array( __CLASS__, 'register_post_types' ), 5 );
 		add_action( 'init', array( __CLASS__, 'support_jetpack_omnisearch' ) );
-		add_filter( 'the_posts', array( __CLASS__, 'show_future_matches' ) );
+		add_action( 'pre_get_posts', array( __CLASS__, 'show_future_matches' ) );
 		add_filter( 'rest_api_allowed_post_types', array( __CLASS__, 'rest_api_allowed_post_types' ) );
 	}
 
@@ -523,18 +523,36 @@ class WPCM_Post_Types {
 	}
 
 	/**
-	 * Show future matches
+	 * Allow future-dated matches to be viewed on the frontend.
 	 *
-	 * @access public
-	 * @param string $posts
-	 * @return string
+	 * WordPress excludes future posts from queries by default, causing
+	 * scheduled matches to return 404. This adds 'future' to the
+	 * post_status query before the SQL is built.
+	 *
+	 * @param WP_Query $query The query object.
 	 */
-	public static function show_future_matches( $posts ) {
-		global $wp_query, $wpdb;
-		if ( is_single() && 0 === $wp_query->post_count && isset( $wp_query->query_vars['wpcm_match'] ) ) {
-			$posts = $wpdb->get_results( $wp_query->request ); // phpcs:ignore
+	public static function show_future_matches( $query ) {
+		if ( ! $query->is_main_query() ) {
+			return;
 		}
-		return $posts;
+
+		$is_match = isset( $query->query_vars['wpcm_match'] ) || 'wpcm_match' === $query->get( 'post_type' );
+
+		if ( $query->is_singular && $is_match ) {
+			$status = $query->get( 'post_status' );
+
+			if ( empty( $status ) ) {
+				$status = array( 'publish' );
+			} elseif ( is_string( $status ) ) {
+				$status = array( $status );
+			}
+
+			if ( ! in_array( 'future', $status, true ) ) {
+				$status[] = 'future';
+			}
+
+			$query->set( 'post_status', $status );
+		}
 	}
 
 	/**

--- a/includes/class-wpcm-shortcodes.php
+++ b/includes/class-wpcm-shortcodes.php
@@ -34,6 +34,7 @@ class WPCM_Shortcodes {
 		// Define shortcodes
 		$shortcodes = array(
 			'match_list'     => __CLASS__ . '::match_list',
+			'match_calendar' => __CLASS__ . '::match_calendar',
 			'player_list'    => __CLASS__ . '::player_list',
 			'player_gallery' => __CLASS__ . '::player_gallery',
 			'staff_list'     => __CLASS__ . '::staff_list',
@@ -101,6 +102,18 @@ class WPCM_Shortcodes {
 	public static function match_list( $atts ) {
 
 		return self::shortcode_wrapper( array( 'WPCM_Shortcode_Match_List', 'output' ), $atts );
+	}
+
+	/**
+	 * Match Calendar shortcode.
+	 *
+	 * @access public
+	 * @param mixed $atts
+	 * @return string
+	 */
+	public static function match_calendar( $atts ) {
+
+		return self::shortcode_wrapper( array( 'WPCM_Shortcode_Match_Calendar', 'output' ), $atts );
 	}
 
 	/**

--- a/includes/class-wpcm-template-loader.php
+++ b/includes/class-wpcm-template-loader.php
@@ -86,6 +86,14 @@ class WPCM_Template_Loader {
 
 		}
 
+		if ( is_single() && get_post_type() === 'wpcm_table' ) {
+
+			$file   = 'single-table.php';
+			$find[] = $file;
+			$find[] = WPCM_TEMPLATE_PATH . $file;
+
+		}
+
 		if ( $file ) {
 			$template = locate_template( $find );
 			if ( ! $template ) {

--- a/includes/shortcodes/class-wpcm-shortcode-league-table.php
+++ b/includes/shortcodes/class-wpcm-shortcode-league-table.php
@@ -115,7 +115,9 @@ class WPCM_Shortcode_League_Table {
 				}
 			}
 
+			wpcm_set_h2h_context( $comp, $season );
 			usort( $clubs, 'wpcm_sort_table_clubs' );
+			wpcm_clear_h2h_context();
 
 			if ( 'ASC' === $order ) {
 				$clubs = array_reverse( $clubs );

--- a/includes/shortcodes/class-wpcm-shortcode-match-calendar.php
+++ b/includes/shortcodes/class-wpcm-shortcode-match-calendar.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Match Calendar Shortcode
+ *
+ * Displays matches in a monthly calendar grid view.
+ *
+ * @author      Clubpress
+ * @category    Shortcodes
+ * @package     WPClubManager/Shortcodes
+ * @version     2.4.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * WPCM_Shortcode_Match_Calendar
+ */
+class WPCM_Shortcode_Match_Calendar {
+
+	/**
+	 * Output the match calendar shortcode.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 */
+	public static function output( $atts ) {
+
+		// Allow query string overrides for calendar navigation.
+		$get_month = isset( $_GET['wpcm_cal_month'] ) ? absint( $_GET['wpcm_cal_month'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
+		$get_year  = isset( $_GET['wpcm_cal_year'] ) ? absint( $_GET['wpcm_cal_year'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
+
+		$month  = $get_month ? $get_month : ( isset( $atts['month'] ) && '' !== $atts['month'] ? absint( $atts['month'] ) : (int) current_time( 'n' ) );
+		$year   = $get_year ? $get_year : ( isset( $atts['year'] ) && '' !== $atts['year'] ? absint( $atts['year'] ) : (int) current_time( 'Y' ) );
+		$comp   = isset( $atts['comp'] ) && '' !== $atts['comp'] ? $atts['comp'] : null;
+		$season = isset( $atts['season'] ) && '' !== $atts['season'] ? $atts['season'] : null;
+		$team   = isset( $atts['team'] ) && '' !== $atts['team'] ? $atts['team'] : null;
+
+		// Clamp month to valid range.
+		if ( $month < 1 || $month > 12 ) {
+			$month = (int) current_time( 'n' );
+		}
+
+		// Clamp year to reasonable range.
+		$current_year = (int) current_time( 'Y' );
+		if ( $year < 1970 || $year > $current_year + 10 ) {
+			$year = $current_year;
+		}
+
+		$effective_atts = array(
+			'month'  => $month,
+			'year'   => $year,
+			'comp'   => $comp,
+			'season' => $season,
+			'team'   => $team,
+		);
+		if ( is_club_mode() ) {
+			$effective_atts['club'] = get_default_club();
+		}
+
+		$disable_cache = get_option( 'wpcm_disable_cache' );
+		if ( 'no' === $disable_cache ) {
+			$transient_name = WPCM_Cache_Helper::create_plugin_transient_name( $effective_atts, 'match_calendar' );
+			$output         = get_transient( $transient_name );
+		} else {
+			$output = false;
+		}
+
+		if ( false === $output ) {
+
+			$site_tz   = wp_timezone();
+			$month_dt  = new DateTimeImmutable( sprintf( '%04d-%02d-01', $year, $month ), $site_tz );
+			$first_day = $month_dt->format( 'Y-m-d' );
+			$last_day  = $month_dt->format( 'Y-m-t' );
+
+			$query_args = array(
+				'tax_query'      => array(), // phpcs:ignore
+				'order'          => 'ASC',
+				'orderby'        => 'post_date',
+				'post_type'      => 'wpcm_match',
+				'post_status'    => array( 'publish', 'future' ),
+				'posts_per_page' => -1,
+				'date_query'     => array(
+					array(
+						'after'     => $first_day,
+						'before'    => $last_day,
+						'inclusive' => true,
+					),
+				),
+			);
+
+			if ( is_club_mode() ) {
+				$club                     = get_default_club();
+				$query_args['meta_query'] = array( // phpcs:ignore
+					'relation' => 'OR',
+					array(
+						'key'   => 'wpcm_home_club',
+						'value' => $club,
+					),
+					array(
+						'key'   => 'wpcm_away_club',
+						'value' => $club,
+					),
+				);
+			}
+
+			if ( isset( $comp ) ) {
+				$query_args['tax_query'][] = array(
+					'taxonomy' => 'wpcm_comp',
+					'terms'    => $comp,
+					'field'    => 'term_id',
+				);
+			}
+			if ( isset( $season ) ) {
+				$query_args['tax_query'][] = array(
+					'taxonomy' => 'wpcm_season',
+					'terms'    => $season,
+					'field'    => 'term_id',
+				);
+			}
+			if ( isset( $team ) ) {
+				$query_args['tax_query'][] = array(
+					'taxonomy' => 'wpcm_team',
+					'terms'    => $team,
+					'field'    => 'term_id',
+				);
+			}
+
+			$matches = get_posts( $query_args );
+
+			// Group matches by day of month.
+			$matches_by_day = array();
+			foreach ( $matches as $match ) {
+				$day = (int) wp_date( 'j', strtotime( $match->post_date ) );
+				if ( ! isset( $matches_by_day[ $day ] ) ) {
+					$matches_by_day[ $day ] = array();
+				}
+				$matches_by_day[ $day ][] = $match;
+			}
+
+			ob_start();
+			wpclubmanager_get_template( 'shortcodes/match-calendar.php', array(
+				'month'          => $month,
+				'year'           => $year,
+				'matches_by_day' => $matches_by_day,
+			) );
+			$output = ob_get_clean();
+
+			wp_reset_postdata();
+			if ( 'no' === $disable_cache ) {
+				set_transient( $transient_name, $output, 4 * WEEK_IN_SECONDS );
+				do_action( 'update_plugin_transient_keys', $transient_name );
+			}
+		}
+
+		echo $output; // phpcs:ignore
+	}
+}

--- a/includes/shortcodes/class-wpcm-shortcode-player-gallery.php
+++ b/includes/shortcodes/class-wpcm-shortcode-player-gallery.php
@@ -47,6 +47,7 @@ class WPCM_Shortcode_Player_Gallery {
 		$linktext    = ( isset( $atts['linktext'] ) ? $atts['linktext'] : __( 'View all players', 'wp-club-manager' ) );
 		$linkpage    = ( isset( $atts['linkpage'] ) ? $atts['linkpage'] : null );
 		$name_format = ( isset( $atts['name_format'] ) ? $atts['name_format'] : 'full' );
+		$linkimage   = ( isset( $atts['linkimage'] ) ? strtolower( trim( $atts['linkimage'] ) ) : 'yes' );
 		$type        = ( isset( $atts['type'] ) ? $atts['type'] : '' );
 
 		if ( '' === $limit ) {
@@ -66,6 +67,9 @@ class WPCM_Shortcode_Player_Gallery {
 		}
 		if ( '' === $name_format ) {
 			$name_format = 'full';
+		}
+		if ( '' === $linkimage ) {
+			$linkimage = 'yes';
 		}
 		if ( '' === $linkpage ) {
 			$linkpage = null;
@@ -129,9 +133,17 @@ class WPCM_Shortcode_Player_Gallery {
 					$url          = get_permalink( $player->ID );
 					$player_title = get_player_title( $player->ID, $name_format );
 
-					$player_details[ $player->ID ]['image'] = apply_filters( 'wpclubmanager_player_gallery_image', '<a href="' . esc_url( $url ) . '">' . $thumb . '</a>', $url, $thumb );
+					if ( 'no' === $linkimage ) {
+						$image_html = $thumb;
+						$title_html = wp_kses_post( $player_title );
+					} else {
+						$image_html = '<a href="' . esc_url( $url ) . '">' . $thumb . '</a>';
+						$title_html = '<a href="' . esc_url( $url ) . '">' . wp_kses_post( $player_title ) . '</a>';
+					}
 
-					$player_details[ $player->ID ]['title'] = apply_filters( 'wpclubmanager_player_gallery_title', '<a href="' . esc_url( $url ) . '">' . wp_kses_post( $player_title ) . '</a>', $url, $player_title );
+					$player_details[ $player->ID ]['image'] = apply_filters( 'wpclubmanager_player_gallery_image', $image_html, $url, $thumb );
+
+					$player_details[ $player->ID ]['title'] = apply_filters( 'wpclubmanager_player_gallery_title', $title_html, $url, $player_title );
 
 					if ( array_key_exists( $orderby, $player_stats_labels ) ) {
 						if ( $team ) {

--- a/includes/wpcm-conditional-functions.php
+++ b/includes/wpcm-conditional-functions.php
@@ -120,6 +120,29 @@ if ( ! function_exists( 'is_plugins_page' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wpcm_is_team_sport' ) ) {
+	/**
+	 * wpcm_is_team_sport - Returns true when the current sport uses teams (home vs away).
+	 *
+	 * Individual sports (e.g. tennis, athletics) return false.
+	 *
+	 * @access public
+	 * @return bool
+	 * @since  2.4.0
+	 */
+	function wpcm_is_team_sport() {
+
+		$sport   = get_option( 'wpcm_sport' );
+		$presets = wpcm_get_sport_presets();
+
+		if ( isset( $presets[ $sport ]['has_teams'] ) ) {
+			return (bool) $presets[ $sport ]['has_teams'];
+		}
+
+		return true;
+	}
+}
+
 if ( ! function_exists( 'is_league_mode' ) ) {
 	/**
 	 * is_league_mode - Returns true when league mode is activated

--- a/includes/wpcm-core-functions.php
+++ b/includes/wpcm-core-functions.php
@@ -202,9 +202,17 @@ function wpcm_get_image_size( $image_size ) {
  */
 function wpcm_flush_rewrite_rules() {
 
-	$post_types = new WPCM_Post_Types();
-	$post_types->register_taxonomies();
-	$post_types->register_post_types();
+	// Unregister existing CPTs so register_post_types() can re-register
+	// them with updated option values (e.g. changed permalink slugs).
+	$wpcm_types = array( 'wpcm_club', 'wpcm_player', 'wpcm_staff', 'wpcm_match', 'wpcm_table', 'wpcm_sponsor', 'wpcm_roster' );
+	foreach ( $wpcm_types as $type ) {
+		if ( post_type_exists( $type ) ) {
+			unregister_post_type( $type );
+		}
+	}
+
+	WPCM_Post_Types::register_taxonomies();
+	WPCM_Post_Types::register_post_types();
 	flush_rewrite_rules();
 }
 

--- a/includes/wpcm-match-functions.php
+++ b/includes/wpcm-match-functions.php
@@ -32,7 +32,13 @@ function match_title( $title, $id = null ) {
 		$home_id      = (int) get_post_meta( $id, 'wpcm_home_club', true );
 		$away_id      = (int) get_post_meta( $id, 'wpcm_away_club', true );
 		$home_club    = get_post( $home_id );
-		$away_club    = get_post( $away_id );
+
+		if ( ! $away_id ) {
+			$title = $home_club ? $home_club->post_title : $title;
+			return $title;
+		}
+
+		$away_club = get_post( $away_id );
 		if ( '%home% vs %away%' === $title_format ) {
 			$side1 = $home_club->post_title;
 			$side2 = $away_club->post_title;
@@ -110,8 +116,27 @@ function wpcm_get_match_outcome( $post ) {
 
 	$club      = (int) get_default_club();
 	$home_club = (int) get_post_meta( $post, 'wpcm_home_club', true );
+	$away_id   = (int) get_post_meta( $post, 'wpcm_away_club', true );
 	$walkover  = get_post_meta( $post, '_wpcm_walkover', true );
 	$postponed = get_post_meta( $post, '_wpcm_postponed', true );
+
+	if ( ! $away_id ) {
+		if ( $postponed ) {
+			if ( '' !== $walkover ) {
+				if ( $club === $home_club ) {
+					return ( 'home_win' === $walkover ) ? 'win' : 'loss';
+				}
+				return ( 'away_win' === $walkover ) ? 'win' : 'loss';
+			}
+			return 'postponed';
+		}
+		if ( ! wpcm_is_team_sport() ) {
+			$played = get_post_meta( $post, 'wpcm_played', true );
+			return $played ? 'win' : '';
+		}
+		return '';
+	}
+
 	if ( get_option( 'wpcm_sport' ) !== 'cricket' ) {
 		if ( get_post_meta( $post, 'wpcm_shootout', true ) ) {
 			$home_goals = get_post_meta( $post, '_wpcm_home_shootout_goals', true );
@@ -174,7 +199,7 @@ if ( ! function_exists( 'wpcm_get_match_result' ) ) {
 	 *
 	 * @param int $post
 	 *
-	 * @return string $result
+	 * @return array $result
 	 * @since  1.4.6
 	 */
 	function wpcm_get_match_result( $post ) {
@@ -188,6 +213,34 @@ if ( ! function_exists( 'wpcm_get_match_result' ) ) {
 		$walkover   = get_post_meta( $post, '_wpcm_walkover', true );
 		$home_goals = get_post_meta( $post, 'wpcm_home_goals', true );
 		$away_goals = get_post_meta( $post, 'wpcm_away_goals', true );
+		$away_id    = (int) get_post_meta( $post, 'wpcm_away_club', true );
+
+		if ( ! $away_id ) {
+			if ( $postponed ) {
+				if ( 'home_win' === $walkover ) {
+					$side1 = _x( 'H', 'HW - home walkover', 'wp-club-manager' );
+					$side2 = _x( 'W', 'HW - home walkover', 'wp-club-manager' );
+				} elseif ( 'away_win' === $walkover ) {
+					$side1 = _x( 'A', 'AW - away walkover', 'wp-club-manager' );
+					$side2 = _x( 'W', 'AW - away walkover', 'wp-club-manager' );
+				} else {
+					$side1 = _x( 'P', 'Postponed', 'wp-club-manager' );
+					$side2 = '';
+				}
+				$result = $side1;
+			} elseif ( 'yes' === $hide && ! is_user_logged_in() ) {
+				$result = ( $played ? __( 'x', 'wp-club-manager' ) : '' );
+				$side1  = __( 'x', 'wp-club-manager' );
+				$side2  = '';
+			} else {
+				$result = ( $played ? $home_goals : '' );
+				$side1  = ( $played ? $home_goals : '' );
+				$side2  = '';
+			}
+
+			return array( $result, $side1, $side2, $delimiter );
+		}
+
 		if ( 'gaelic' === $sport ) {
 			$home_gaa_goals  = get_post_meta( $post, 'wpcm_home_gaa_goals', true );
 			$home_gaa_points = get_post_meta( $post, 'wpcm_home_gaa_points', true );
@@ -373,6 +426,15 @@ function wpcm_get_match_clubs( $post, $abbr = false ) {
 	$home_club = get_post_meta( $post, 'wpcm_home_club', true );
 	$away_club = get_post_meta( $post, 'wpcm_away_club', true );
 
+	if ( ! $away_club ) {
+		if ( false === $abbr ) {
+			$side1 = wpcm_get_team_name( $home_club, $post );
+		} else {
+			$side1 = get_club_abbreviation( $home_club );
+		}
+		return array( $side1, '' );
+	}
+
 	if ( false === $abbr ) {
 		if ( '%home% vs %away%' === $format ) {
 			$side1 = wpcm_get_team_name( $home_club, $post );
@@ -409,6 +471,11 @@ function wpcm_get_match_opponents( $post, $abbr = false ) {
 	$home_club = get_post_meta( $post, 'wpcm_home_club', true );
 	$away_club = get_post_meta( $post, 'wpcm_away_club', true );
 	$opponent  = '';
+
+	if ( ! $away_club ) {
+		return $opponent;
+	}
+
 	if ( false === $abbr ) {
 		if ( $club === $home_club ) {
 			$opponent = get_the_title( $away_club, true );
@@ -441,6 +508,15 @@ function wpcm_get_match_badges( $post, $size = null, $args = null ) {
 	$format    = get_match_title_format();
 	$home_club = get_post_meta( $post, 'wpcm_home_club', true );
 	$away_club = get_post_meta( $post, 'wpcm_away_club', true );
+
+	if ( ! $away_club ) {
+		if ( has_post_thumbnail( $home_club ) ) {
+			$badge1 = get_the_post_thumbnail( $home_club, $size, $args );
+		} else {
+			$badge1 = wpcm_crest_placeholder_img( $size );
+		}
+		return array( $badge1, '' );
+	}
 
 	if ( '%home% vs %away%' === $format ) {
 		if ( has_post_thumbnail( $home_club ) ) {

--- a/includes/wpcm-match-functions.php
+++ b/includes/wpcm-match-functions.php
@@ -550,7 +550,7 @@ function wpcm_get_match_badges( $post, $size = null, $args = null ) {
  *
  * @access public
  * @param int $post
- * @return string $venue
+ * @return array{name: string|null, id: int|null, description: string|null, address: string|null, capacity: string|null, status: string} $venue
  * @since 1.4.6
  */
 function wpcm_get_match_venue( $post ) {

--- a/includes/wpcm-preset-functions.php
+++ b/includes/wpcm-preset-functions.php
@@ -22,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function wpcm_get_sport_presets() {
 	return apply_filters( 'wpcm_sports', array(
 		'baseball'     => array(
+			'has_teams'         => true,
 			'name'              => __( 'Baseball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -145,6 +146,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'basketball'   => array(
+			'has_teams'         => true,
 			'name'              => __( 'Basketball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -292,6 +294,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'cricket'      => array(
+			'has_teams'         => true,
 			'name'              => __( 'Cricket', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -416,6 +419,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'floorball'    => array(
+			'has_teams'         => true,
 			'name'              => __( 'Floorball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -511,6 +515,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'football'     => array(
+			'has_teams'         => true,
 			'name'              => __( 'American Football', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -690,6 +695,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'footy'        => array(
+			'has_teams'         => true,
 			'name'              => __( 'Australian Rules Football', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -857,6 +863,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'gaelic'       => array(
+			'has_teams'         => true,
 			'name'              => __( 'Gaelic Football / Hurling', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -952,6 +959,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'handball'     => array(
+			'has_teams'         => true,
 			'name'              => __( 'Handball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1047,6 +1055,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'hockey_field' => array(
+			'has_teams'         => true,
 			'name'              => __( 'Field Hockey', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1146,6 +1155,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'hockey'       => array(
+			'has_teams'         => true,
 			'name'              => __( 'Ice Hockey', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1273,6 +1283,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'lacrosse'     => array(
+			'has_teams'         => true,
 			'name'              => __( 'Lacrosse', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1356,6 +1367,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'netball'      => array(
+			'has_teams'         => true,
 			'name'              => __( 'Netball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1471,6 +1483,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'rugby_league' => array(
+			'has_teams'         => true,
 			'name'              => __( 'Rugby League', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1582,6 +1595,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'rugby'        => array(
+			'has_teams'         => true,
 			'name'              => __( 'Rugby Union', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1701,6 +1715,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'soccer'       => array(
+			'has_teams'         => true,
 			'name'              => __( 'Football (Soccer)', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(
@@ -1796,6 +1811,7 @@ function wpcm_get_sport_presets() {
 			),
 		),
 		'volleyball'   => array(
+			'has_teams'         => true,
 			'name'              => __( 'Volleyball', 'wp-club-manager' ),
 			'terms'             => array(
 				'wpcm_position' => array(

--- a/includes/wpcm-standings-functions.php
+++ b/includes/wpcm-standings-functions.php
@@ -35,38 +35,20 @@ if ( ! function_exists( 'wpcm_club_standings_sort' ) ) {
 		$priority_2 = get_option( 'wpcm_standings_orderby_2' );
 		$priority_3 = get_option( 'wpcm_standings_orderby_3' );
 
-		if ( $a->wpcm_stats[ $priority_1 ] > $b->wpcm_stats[ $priority_1 ] ) {
-
-			return -1;
-
-		} elseif ( $a->wpcm_stats[ $priority_1 ] < $b->wpcm_stats[ $priority_1 ] ) {
-
-			return 1;
-
-		} elseif ( $a->wpcm_stats[ $priority_2 ] > $b->wpcm_stats[ $priority_2 ] ) {
-
+		$priorities = array( $priority_1, $priority_2, $priority_3 );
+		foreach ( $priorities as $col ) {
+			// Skip H2H — not supported in the legacy standings shortcode sorter.
+			if ( 'h2h' === $col || ! isset( $a->wpcm_stats[ $col ], $b->wpcm_stats[ $col ] ) ) {
+				continue;
+			}
+			if ( $a->wpcm_stats[ $col ] > $b->wpcm_stats[ $col ] ) {
 				return -1;
-
-		} elseif ( $a->wpcm_stats[ $priority_2 ] < $b->wpcm_stats[ $priority_2 ] ) {
-
-			return 1;
-
-		} elseif ( $a->wpcm_stats[ $priority_3 ] > $b->wpcm_stats[ $priority_3 ] ) {
-
-				return -1;
-
-		} elseif ( $a->wpcm_stats[ $priority_3 ] < $b->wpcm_stats[ $priority_3 ] ) {
-
-			return 1;
-
-		} elseif ( strcmp( $a->post_title, $b->post_title ) < 0 ) {
-
-				return -1;
-
-		} else {
-
-			return 1;
+			} elseif ( $a->wpcm_stats[ $col ] < $b->wpcm_stats[ $col ] ) {
+				return 1;
+			}
 		}
+
+		return strcmp( $a->post_title, $b->post_title );
 	}
 }
 
@@ -225,6 +207,267 @@ if ( ! function_exists( 'get_wpcm_table_total_stats' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wpcm_set_h2h_context' ) ) {
+	/**
+	 * Store competition and season context for head-to-head lookups during sorting.
+	 *
+	 * @param int|null $comp   Competition term ID (null = no restriction).
+	 * @param int|null $season Season term ID (null = no restriction).
+	 */
+	function wpcm_set_h2h_context( $comp, $season ) {
+		global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_context_set;
+		$wpcm_h2h_comp        = $comp;
+		$wpcm_h2h_season      = $season;
+		$wpcm_h2h_context_set = true;
+	}
+}
+
+if ( ! function_exists( 'wpcm_clear_h2h_context' ) ) {
+	/**
+	 * Clear H2H context and in-memory cache after sorting is complete.
+	 */
+	function wpcm_clear_h2h_context() {
+		global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_context_set;
+		$wpcm_h2h_comp        = null;
+		$wpcm_h2h_season      = null;
+		$wpcm_h2h_context_set = false;
+		wpcm_h2h_cache_reset();
+	}
+}
+
+if ( ! function_exists( 'wpcm_h2h_cache_reset' ) ) {
+	/**
+	 * Reset the in-memory H2H results cache.
+	 */
+	function wpcm_h2h_cache_reset() {
+		global $wpcm_h2h_cache;
+		$wpcm_h2h_cache = array();
+	}
+}
+
+if ( ! function_exists( 'wpcm_get_h2h_points' ) ) {
+	/**
+	 * Calculate head-to-head record between two clubs in the current H2H context.
+	 *
+	 * Results are cached in-memory for the duration of the request to avoid
+	 * repeated database queries when called from a usort comparator.
+	 *
+	 * Returns points, goal difference, and goals scored for each club
+	 * based only on their direct matches in the given competition and season.
+	 *
+	 * @param int $club_a_id Club A post ID.
+	 * @param int $club_b_id Club B post ID.
+	 * @return array {
+	 *     @type int $a_points Points earned by club A in H2H matches.
+	 *     @type int $b_points Points earned by club B in H2H matches.
+	 *     @type int $a_gd     Goal difference for club A in H2H matches.
+	 *     @type int $b_gd     Goal difference for club B in H2H matches.
+	 *     @type int $a_goals  Goals scored by club A in H2H matches.
+	 *     @type int $b_goals  Goals scored by club B in H2H matches.
+	 * }
+	 */
+	function wpcm_get_h2h_points( $club_a_id, $club_b_id ) {
+		global $wpcm_h2h_comp, $wpcm_h2h_season, $wpcm_h2h_cache, $wpcm_h2h_context_set;
+
+		$neutral = array(
+			'a_points' => 0,
+			'b_points' => 0,
+			'a_gd'     => 0,
+			'b_gd'     => 0,
+			'a_goals'  => 0,
+			'b_goals'  => 0,
+		);
+
+		if ( ! is_array( $wpcm_h2h_cache ) ) {
+			$wpcm_h2h_cache = array();
+		}
+		$cache = &$wpcm_h2h_cache;
+
+		// Return neutral result when H2H context was never set by a caller.
+		if ( empty( $wpcm_h2h_context_set ) ) {
+			return $neutral;
+		}
+
+		// Normalise cache key so (A,B) and (B,A) share the same entry.
+		$lo       = min( $club_a_id, $club_b_id );
+		$hi       = max( $club_a_id, $club_b_id );
+		$comp_key = $wpcm_h2h_comp ? $wpcm_h2h_comp : '0';
+		$ssn_key  = $wpcm_h2h_season ? $wpcm_h2h_season : '0';
+		$key      = "{$comp_key}_{$ssn_key}_{$lo}_{$hi}";
+
+		if ( isset( $cache[ $key ] ) ) {
+			$cached = $cache[ $key ];
+			if ( $club_a_id === $lo ) {
+				return $cached;
+			}
+			return array(
+				'a_points' => $cached['b_points'],
+				'b_points' => $cached['a_points'],
+				'a_gd'     => $cached['b_gd'],
+				'b_gd'     => $cached['a_gd'],
+				'a_goals'  => $cached['b_goals'],
+				'b_goals'  => $cached['a_goals'],
+			);
+		}
+
+		$sport    = get_option( 'wpcm_sport' );
+		$win_pts  = (int) get_option( 'wpcm_standings_win_points', 3 );
+		$draw_pts = (int) get_option( 'wpcm_standings_draw_points', 1 );
+		$loss_pts = (int) get_option( 'wpcm_standings_loss_points', 0 );
+		$otw_pts  = (int) get_option( 'wpcm_standings_otw_points', 0 );
+		$otl_pts  = (int) get_option( 'wpcm_standings_otl_points', 1 );
+
+		$result = $neutral;
+
+		$tax_query = array();
+		if ( $wpcm_h2h_comp ) {
+			$tax_query[] = array(
+				'taxonomy' => 'wpcm_comp',
+				'terms'    => $wpcm_h2h_comp,
+				'field'    => 'term_id',
+			);
+		}
+		if ( $wpcm_h2h_season ) {
+			$tax_query[] = array(
+				'taxonomy' => 'wpcm_season',
+				'terms'    => $wpcm_h2h_season,
+				'field'    => 'term_id',
+			);
+		}
+
+		// Query both directions (A home / B away, and B home / A away) using OR.
+		$args = array(
+			'post_type'              => 'wpcm_match',
+			'posts_per_page'         => -1,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'suppress_filters'       => true,
+			'meta_query'             => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'relation' => 'OR',
+				array(
+					'relation' => 'AND',
+					array(
+						'key'   => 'wpcm_home_club',
+						'value' => $club_a_id,
+					),
+					array(
+						'key'   => 'wpcm_away_club',
+						'value' => $club_b_id,
+					),
+				),
+				array(
+					'relation' => 'AND',
+					array(
+						'key'   => 'wpcm_home_club',
+						'value' => $club_b_id,
+					),
+					array(
+						'key'   => 'wpcm_away_club',
+						'value' => $club_a_id,
+					),
+				),
+			),
+			'tax_query'              => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+		);
+
+		$match_ids = get_posts( $args );
+
+		foreach ( $match_ids as $match_id ) {
+			$played    = (int) get_post_meta( $match_id, 'wpcm_played', true );
+			$friendly  = (int) get_post_meta( $match_id, 'wpcm_friendly', true );
+			$postponed = (int) get_post_meta( $match_id, '_wpcm_postponed', true );
+			$walkover  = get_post_meta( $match_id, '_wpcm_walkover', true );
+			$overtime  = (int) get_post_meta( $match_id, 'wpcm_overtime', true );
+
+			$home_id = (int) get_post_meta( $match_id, 'wpcm_home_club', true );
+			// Determine which club is "a" and which is "b" in this match.
+			$a_is_home = ( $home_id === $club_a_id );
+
+			// Handle walkover outcomes for postponed matches.
+			if ( $postponed ) {
+				if ( 'home_win' === $walkover ) {
+					if ( $a_is_home ) {
+						$result['a_points'] += $win_pts;
+						$result['b_points'] += $loss_pts;
+					} else {
+						$result['b_points'] += $win_pts;
+						$result['a_points'] += $loss_pts;
+					}
+				} elseif ( 'away_win' === $walkover ) {
+					if ( $a_is_home ) {
+						$result['a_points'] += $loss_pts;
+						$result['b_points'] += $win_pts;
+					} else {
+						$result['b_points'] += $loss_pts;
+						$result['a_points'] += $win_pts;
+					}
+				}
+				continue;
+			}
+
+			if ( ! $played || $friendly ) {
+				continue;
+			}
+
+			$home_goals = (int) get_post_meta( $match_id, 'wpcm_home_goals', true );
+			$away_goals = (int) get_post_meta( $match_id, 'wpcm_away_goals', true );
+
+			if ( $a_is_home ) {
+				$a_goals = $home_goals;
+				$b_goals = $away_goals;
+			} else {
+				$a_goals = $away_goals;
+				$b_goals = $home_goals;
+			}
+
+			$result['a_goals'] += $a_goals;
+			$result['b_goals'] += $b_goals;
+			$result['a_gd']    += $a_goals - $b_goals;
+			$result['b_gd']    += $b_goals - $a_goals;
+
+			// Use overtime-aware points for hockey/basketball.
+			if ( $a_goals > $b_goals ) {
+				if ( $overtime && in_array( $sport, array( 'hockey', 'basketball' ), true ) ) {
+					$result['a_points'] += $otw_pts;
+					$result['b_points'] += $otl_pts;
+				} else {
+					$result['a_points'] += $win_pts;
+					$result['b_points'] += $loss_pts;
+				}
+			} elseif ( $a_goals < $b_goals ) {
+				if ( $overtime && in_array( $sport, array( 'hockey', 'basketball' ), true ) ) {
+					$result['a_points'] += $otl_pts;
+					$result['b_points'] += $otw_pts;
+				} else {
+					$result['a_points'] += $loss_pts;
+					$result['b_points'] += $win_pts;
+				}
+			} else {
+				$result['a_points'] += $draw_pts;
+				$result['b_points'] += $draw_pts;
+			}
+		}
+
+		// Store result in cache, keyed with the lower ID first.
+		if ( $club_a_id === $lo ) {
+			$cache[ $key ] = $result;
+		} else {
+			$cache[ $key ] = array(
+				'a_points' => $result['b_points'],
+				'b_points' => $result['a_points'],
+				'a_gd'     => $result['b_gd'],
+				'b_gd'     => $result['a_gd'],
+				'a_goals'  => $result['b_goals'],
+				'b_goals'  => $result['a_goals'],
+			);
+		}
+
+		return $result;
+	}
+}
+
 if ( ! function_exists( 'wpcm_table_priorities' ) ) {
 	/**
 	 * @return array
@@ -251,8 +494,8 @@ if ( ! function_exists( 'wpcm_table_priorities' ) ) {
 
 if ( ! function_exists( 'wpcm_sort_table_clubs' ) ) {
 	/**
-	 * @param array $a
-	 * @param array $b
+	 * @param object $a
+	 * @param object $b
 	 *
 	 * @return int
 	 */
@@ -262,6 +505,41 @@ if ( ! function_exists( 'wpcm_sort_table_clubs' ) ) {
 
 		// Loop through priorities
 		foreach ( $priorities as $priority ) {
+
+			if ( 'h2h' === $priority['column'] ) {
+				// Head-to-head tiebreaker: compare direct match record.
+				$h2h = wpcm_get_h2h_points( $a->ID, $b->ID );
+
+				// Compare H2H points first.
+				if ( $h2h['a_points'] !== $h2h['b_points'] ) {
+					$output = $h2h['a_points'] - $h2h['b_points'];
+					if ( 'DESC' === $priority['order'] ) {
+						$output = 0 - $output;
+					}
+					return ( $output > 0 ? 1 : -1 );
+				}
+
+				// If H2H points tied, compare H2H goal difference.
+				if ( $h2h['a_gd'] !== $h2h['b_gd'] ) {
+					$output = $h2h['a_gd'] - $h2h['b_gd'];
+					if ( 'DESC' === $priority['order'] ) {
+						$output = 0 - $output;
+					}
+					return ( $output > 0 ? 1 : -1 );
+				}
+
+				// If H2H GD tied, compare H2H goals scored.
+				if ( $h2h['a_goals'] !== $h2h['b_goals'] ) {
+					$output = $h2h['a_goals'] - $h2h['b_goals'];
+					if ( 'DESC' === $priority['order'] ) {
+						$output = 0 - $output;
+					}
+					return ( $output > 0 ? 1 : -1 );
+				}
+
+				// H2H completely tied, fall through to next priority.
+				continue;
+			}
 
 			if ( wpcm_array_value( $a->wpcm_stats, $priority['column'], 0 ) !== wpcm_array_value( $b->wpcm_stats, $priority['column'], 0 ) ) {
 
@@ -279,7 +557,6 @@ if ( ! function_exists( 'wpcm_sort_table_clubs' ) ) {
 		}
 
 		// Default sort by alphabetical
-		// return strcmp( wpcm_array_value( $a, 'name', '' ), wpcm_array_value( $b, 'name', '' ) );
 		return strcmp( $a->post_name, $b->post_name );
 	}
 }

--- a/includes/wpcm-stats-functions.php
+++ b/includes/wpcm-stats-functions.php
@@ -546,7 +546,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 	/**
 	 * Get total player stats.
 	 *
-	 * @param WP_Post $post
+	 * @param WP_Post|int|null $post Player post object or ID.
 	 *
 	 * @return array
 	 */
@@ -556,9 +556,11 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 			global $post;
 		}
 
+		$post_id = ( $post instanceof WP_Post ) ? $post->ID : $post;
+
 		$output  = array();
-		$teams   = wp_get_object_terms( $post, 'wpcm_team', array( 'orderby' => 'tax_position' ) );
-		$seasons = wp_get_object_terms( $post, 'wpcm_season', array( 'orderby' => 'tax_position' ) );
+		$teams   = wp_get_object_terms( $post_id, 'wpcm_team', array( 'orderby' => 'tax_position' ) );
+		$seasons = wp_get_object_terms( $post_id, 'wpcm_season', array( 'orderby' => 'tax_position' ) );
 
 		// isolated team stats
 		if ( is_array( $teams ) ) {
@@ -566,7 +568,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 			foreach ( $teams as $team ) {
 
 				// combined season stats per team
-				$stats                       = get_wpcm_player_auto_stats( $post, $team->term_id, null );
+				$stats                       = get_wpcm_player_auto_stats( $post_id, $team->term_id, null );
 				$output[ $team->term_id ][0] = array(
 					'auto'  => $stats,
 					'total' => $stats,
@@ -577,7 +579,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 
 					foreach ( $seasons as $season ) {
 
-						$stats                                        = get_wpcm_player_auto_stats( $post, $team->term_id, $season->term_id );
+						$stats                                        = get_wpcm_player_auto_stats( $post_id, $team->term_id, $season->term_id );
 						$output[ $team->term_id ][ $season->term_id ] = array(
 							'auto'  => $stats,
 							'total' => $stats,
@@ -588,8 +590,8 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 		}
 
 		// combined season stats for combined team
-		$stats        = get_wpcm_player_auto_stats( $post );
-		$manual_stats = get_wpcm_player_manual_stats( $post, $team->term_id, $season->term_id );
+		$stats        = get_wpcm_player_auto_stats( $post_id );
+		$manual_stats = get_wpcm_player_manual_stats( $post_id );
 		$output[0][0] = array(
 			'auto'   => $stats,
 			'total'  => $stats,
@@ -601,7 +603,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 
 			foreach ( $seasons as $season ) {
 
-				$stats                         = get_wpcm_player_auto_stats( $post, null, $season->term_id );
+				$stats                         = get_wpcm_player_auto_stats( $post_id, null, $season->term_id );
 				$output[0][ $season->term_id ] = array(
 					'auto'  => $stats,
 					'total' => $stats,
@@ -610,7 +612,7 @@ if ( ! function_exists( 'get_wpcm_player_stats' ) ) {
 		}
 
 		// manual stats
-		$manual_stats = (array) maybe_unserialize( get_post_meta( $post, 'wpcm_stats', true ) );
+		$manual_stats = (array) maybe_unserialize( get_post_meta( $post_id, 'wpcm_stats', true ) );
 
 		if ( is_array( $manual_stats ) ) {
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wp-club-manager",
   "title": "WP Club Manager",
   "description": "Plugin",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "homepage": "https://wpclubmanager.com",
   "author": {
     "name": "WP Club Manager",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -316,11 +316,6 @@ parameters:
 			path: includes/admin/importers/class-wpcm-match-importer.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: includes/admin/importers/class-wpcm-player-importer.php
-
-		-
 			message: "#^Parameter \\#1 \\$post of function get_club_details expects array, WP_Post given\\.$#"
 			count: 1
 			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-club-details.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1636,11 +1636,6 @@ parameters:
 			path: includes/wpcm-match-functions.php
 
 		-
-			message: "#^Function wpcm_get_match_result\\(\\) should return string but returns array\\<int, mixed\\>\\.$#"
-			count: 1
-			path: includes/wpcm-match-functions.php
-
-		-
 			message: "#^Function wpcm_get_match_venue\\(\\) should return string but returns array\\<string, mixed\\>\\.$#"
 			count: 1
 			path: includes/wpcm-match-functions.php
@@ -1832,7 +1827,7 @@ parameters:
 
 		-
 			message: "#^Variable \\$sides might not be defined\\.$#"
-			count: 2
+			count: 1
 			path: templates/content-widget-fixtures.php
 
 		-
@@ -1887,7 +1882,7 @@ parameters:
 
 		-
 			message: "#^Variable \\$sides might not be defined\\.$#"
-			count: 2
+			count: 1
 			path: templates/content-widget-results.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,11 +91,6 @@ parameters:
 			path: includes/admin/class-wpcm-admin-dashboard.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(WP_Post, WP_Post\\)\\: int, 'wpcm_sort_table…' given\\.$#"
-			count: 2
-			path: includes/admin/class-wpcm-admin-dashboard.php
-
-		-
 			message: "#^Parameter \\#6 \\$callback of function add_submenu_page expects ''\\|\\(callable\\(\\)\\: mixed\\), false given\\.$#"
 			count: 5
 			path: includes/admin/class-wpcm-admin-menus.php
@@ -567,11 +562,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$text of function esc_html expects string, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-table-stats.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(WP_Post, WP_Post\\)\\: int, 'wpcm_sort_table…' given\\.$#"
 			count: 1
 			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-table-stats.php
 
@@ -1351,11 +1341,6 @@ parameters:
 			path: includes/shortcodes/class-wpcm-shortcode-league-table.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(WP_Post, WP_Post\\)\\: int, 'wpcm_sort_table…' given\\.$#"
-			count: 1
-			path: includes/shortcodes/class-wpcm-shortcode-league-table.php
-
-		-
 			message: "#^Variable \\$transient_name might not be defined\\.$#"
 			count: 2
 			path: includes/shortcodes/class-wpcm-shortcode-league-table.php
@@ -1694,16 +1679,6 @@ parameters:
 			message: "#^Variable \\$season might not be defined\\.$#"
 			count: 1
 			path: includes/wpcm-player-functions.php
-
-		-
-			message: "#^Cannot access property \\$post_name on array\\.$#"
-			count: 2
-			path: includes/wpcm-standings-functions.php
-
-		-
-			message: "#^Cannot access property \\$wpcm_stats on array\\.$#"
-			count: 4
-			path: includes/wpcm-standings-functions.php
 
 		-
 			message: "#^Comparison operation \"\\>\" between \\(array\\|float\\|int\\) and 0 results in an error\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,11 +51,6 @@ parameters:
 			path: includes/admin/class-wpcm-admin-dashboard-widgets.php
 
 		-
-			message: "#^Variable \\$competition might not be defined\\.$#"
-			count: 1
-			path: includes/admin/class-wpcm-admin-dashboard-widgets.php
-
-		-
 			message: "#^Access to an undefined property WP_Post\\:\\:\\$place\\.$#"
 			count: 2
 			path: includes/admin/class-wpcm-admin-dashboard.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -551,11 +551,6 @@ parameters:
 			path: includes/admin/settings/class-wpcm-settings-general.php
 
 		-
-			message: "#^Offset 'name' does not exist on string\\.$#"
-			count: 2
-			path: includes/admin/views/html-admin-page-dashboard.php
-
-		-
 			message: "#^Variable \\$a_label might not be defined\\.$#"
 			count: 1
 			path: includes/admin/views/html-admin-page-dashboard.php
@@ -664,11 +659,6 @@ parameters:
 			message: "#^Variable \\$win_percent might not be defined\\.$#"
 			count: 1
 			path: includes/admin/views/html-admin-page-dashboard.php
-
-		-
-			message: "#^Offset 'name' does not exist on string\\.$#"
-			count: 2
-			path: includes/admin/views/html-admin-page-league-dashboard.php
 
 		-
 			message: "#^Variable \\$clubs might not be defined\\.$#"
@@ -1596,11 +1586,6 @@ parameters:
 			path: includes/wpcm-match-functions.php
 
 		-
-			message: "#^Function wpcm_get_match_venue\\(\\) should return string but returns array\\<string, mixed\\>\\.$#"
-			count: 1
-			path: includes/wpcm-match-functions.php
-
-		-
 			message: "#^Variable \\$label might not be defined\\.$#"
 			count: 1
 			path: includes/wpcm-match-functions.php
@@ -1956,11 +1941,6 @@ parameters:
 			path: templates/shortcodes/match-list.php
 
 		-
-			message: "#^Offset 'status' does not exist on string\\.$#"
-			count: 1
-			path: templates/shortcodes/match-opponents.php
-
-		-
 			message: "#^Variable \\$away_badge might not be defined\\.$#"
 			count: 1
 			path: templates/shortcodes/match-opponents.php
@@ -2025,10 +2005,6 @@ parameters:
 			count: 1
 			path: templates/shortcodes/matches-2.php
 
-		-
-			message: "#^Offset 'status' does not exist on string\\.$#"
-			count: 1
-			path: templates/shortcodes/matches.php
 
 		-
 			message: "#^Variable \\$away_badge might not be defined\\.$#"
@@ -2266,27 +2242,7 @@ parameters:
 			path: templates/single-match/lineup.php
 
 		-
-			message: "#^Offset 'address' does not exist on string\\.$#"
-			count: 2
-			path: templates/single-match/venue-info.php
-
-		-
-			message: "#^Offset 'description' does not exist on string\\.$#"
-			count: 1
-			path: templates/single-match/venue-info.php
-
-		-
-			message: "#^Offset 'id' does not exist on string\\.$#"
-			count: 1
-			path: templates/single-match/venue-info.php
-
-		-
-			message: "#^Offset 'name' does not exist on string\\.$#"
-			count: 1
-			path: templates/single-match/venue-info.php
-
-		-
-			message: "#^Offset 'name' does not exist on non\\-falsy\\-string\\.$#"
+			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: templates/single-match/venue.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,11 +116,6 @@ parameters:
 			path: includes/admin/class-wpcm-admin-permalink-settings.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$request\\.$#"
-			count: 1
-			path: includes/admin/class-wpcm-admin-post-types.php
-
-		-
 			message: "#^Action callback returns int but should not return anything\\.$#"
 			count: 1
 			path: includes/admin/class-wpcm-admin-post-types.php
@@ -899,11 +894,6 @@ parameters:
 			message: "#^Variable \\$_optname in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: includes/class-wpcm-license.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$request\\.$#"
-			count: 1
-			path: includes/class-wpcm-post-types.php
 
 		-
 			message: "#^Left side of && is always true\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -441,11 +441,6 @@ parameters:
 			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-stats.php
 
 		-
-			message: "#^Parameter \\#1 \\$post of function get_wpcm_player_stats expects WP_Post\\|null, int given\\.$#"
-			count: 1
-			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-stats.php
-
-		-
 			message: "#^Parameter \\#1 \\$post_id of function get_post_meta expects int, string given\\.$#"
 			count: 1
 			path: includes/admin/post-types/meta-boxes/class-wpcm-meta-box-player-stats.php
@@ -1366,19 +1361,9 @@ parameters:
 			path: includes/shortcodes/class-wpcm-shortcode-match-opponents.php
 
 		-
-			message: "#^Parameter \\#1 \\$post of function get_wpcm_player_stats expects WP_Post\\|null, int given\\.$#"
-			count: 1
-			path: includes/shortcodes/class-wpcm-shortcode-player-gallery.php
-
-		-
 			message: "#^Variable \\$transient_name might not be defined\\.$#"
 			count: 2
 			path: includes/shortcodes/class-wpcm-shortcode-player-gallery.php
-
-		-
-			message: "#^Parameter \\#1 \\$post of function get_wpcm_player_stats expects WP_Post\\|null, int given\\.$#"
-			count: 1
-			path: includes/shortcodes/class-wpcm-shortcode-player-list.php
 
 		-
 			message: "#^Undefined variable\\: \\$natl$#"
@@ -1427,11 +1412,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$args of function get_posts expects array\\{numberposts\\?\\: int, category\\?\\: int\\|string, include\\?\\: array\\<int\\>, exclude\\?\\: array\\<int\\>, suppress_filters\\?\\: bool, attachment_id\\?\\: int, author\\?\\: int\\|string, author_name\\?\\: string, \\.\\.\\.\\}\\|null, array\\{post_type\\: 'wpcm_player', tax_query\\: array\\{\\}\\|array\\{0\\: array\\{taxonomy\\: 'wpcm_season', terms\\: mixed, field\\: 'term_id'\\}, 1\\?\\: array\\{taxonomy\\: 'wpcm_position'\\|'wpcm_team', terms\\: mixed, field\\: 'term_id'\\}, 2\\?\\: array\\{taxonomy\\: 'wpcm_position', terms\\: mixed, field\\: 'term_id'\\}\\}\\|array\\{0\\: array\\{taxonomy\\: 'wpcm_team', terms\\: mixed, field\\: 'term_id'\\}, 1\\?\\: array\\{taxonomy\\: 'wpcm_position', terms\\: mixed, field\\: 'term_id'\\}\\}\\|array\\{array\\{taxonomy\\: 'wpcm_position', terms\\: mixed, field\\: 'term_id'\\}\\}, numposts\\: mixed, posts_per_page\\: mixed, orderby\\: 'menu_order'\\|'meta_value_num'\\|'name', meta_key\\: 'wpcm_number', order\\: string, suppress_filters\\: 0\\} given\\.$#"
-			count: 1
-			path: includes/shortcodes/legacy/class-wpcm-shortcode-players.php
-
-		-
-			message: "#^Parameter \\#1 \\$post of function get_wpcm_player_stats expects WP_Post\\|null, int given\\.$#"
 			count: 1
 			path: includes/shortcodes/legacy/class-wpcm-shortcode-players.php
 
@@ -1716,33 +1696,13 @@ parameters:
 			path: includes/wpcm-stats-functions.php
 
 		-
-			message: "#^Parameter \\#2 \\$team of function get_wpcm_player_manual_stats expects string\\|null, int given\\.$#"
-			count: 1
-			path: includes/wpcm-stats-functions.php
-
-		-
 			message: "#^Parameter \\#3 \\$season of function get_wpcm_club_auto_stats expects int\\|null, string\\|null given\\.$#"
-			count: 1
-			path: includes/wpcm-stats-functions.php
-
-		-
-			message: "#^Parameter \\#3 \\$season of function get_wpcm_player_manual_stats expects string\\|null, int given\\.$#"
 			count: 1
 			path: includes/wpcm-stats-functions.php
 
 		-
 			message: "#^Parameter \\#3 \\$season_id of function get_wpcm_player_auto_stats expects string\\|null, int given\\.$#"
 			count: 2
-			path: includes/wpcm-stats-functions.php
-
-		-
-			message: "#^Variable \\$season might not be defined\\.$#"
-			count: 1
-			path: includes/wpcm-stats-functions.php
-
-		-
-			message: "#^Variable \\$team might not be defined\\.$#"
-			count: 1
 			path: includes/wpcm-stats-functions.php
 
 		-

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Requires at least: 4.9
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable Tag: 2.3.3
+Stable Tag: 2.4.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -170,6 +170,20 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 11. Front-end League Table
 
 == Changelog ==
+
+= 2.4.0 - 25th May 2026 =
+
+* Feature: Recreate shortcodes as Gutenberg blocks
+* Feature: Head-to-head sorting in league tables
+* Feature: Support individual/non-team sports
+* Feature: Option to remove link on player photo in gallery
+* Feature: Include all settings in export/import
+* Add: Match calendar view with iCal support
+* Fix: Match import not finding existing competitions/teams
+* Fix: 404 error on league table pages
+* Fix: Accented characters broken in permalinks
+* Fix: Scheduled matches returning 404 on frontend
+* Fix: Dashboard widget PHP warnings and stats query
 
 = 2.3.3 - 13th April 2026 =
 

--- a/templates/content-single-table.php
+++ b/templates/content-single-table.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * The template for displaying league table content in the single-table.php template
+ *
+ * Override this template by copying it to yourtheme/wpclubmanager/content-single-table.php
+ *
+ * @author      ClubPress
+ * @package     WPClubManager/Templates
+ * @version     2.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+	<?php do_action( 'wpclubmanager_before_single_table' ); ?>
+
+	<header class="entry-header">
+		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+	</header>
+
+	<div class="wpcm-table-details wpcm-row">
+		<?php echo do_shortcode( '[league_table id="' . absint( get_the_ID() ) . '"]' ); ?>
+	</div>
+
+	<?php do_action( 'wpclubmanager_after_single_table' ); ?>
+
+</article>

--- a/templates/content-widget-fixtures.php
+++ b/templates/content-widget-fixtures.php
@@ -35,10 +35,12 @@ $timestamp = strtotime( $post->post_date ); ?>
 				<div class="home-logo"><?php echo wp_kses_post( $badges[0] ); ?></div>
 				<?php echo esc_html( $sides[0] ); ?>
 			</h4>
+			<?php if ( ! empty( $sides[1] ) ) : ?>
 			<h4 class="away-clubs">
 				<div class="away-logo"><?php echo wp_kses_post( $badges[1] ); ?></div>
 				<?php echo esc_html( $sides[1] ); ?>
 			</h4>
+			<?php endif; ?>
 		</div>
 	</a>
 	<div class="wpcm-date">

--- a/templates/content-widget-results.php
+++ b/templates/content-widget-results.php
@@ -36,11 +36,13 @@ $timestamp = strtotime( $post->post_date ); ?>
 				<?php echo esc_html( $sides[0] ); ?>
 				<div class="score"><?php echo ( $played && $show_score ? esc_html( $score[1] ) : '' ); ?></div>
 			</h4>
+			<?php if ( ! empty( $sides[1] ) ) : ?>
 			<h4 class="away-clubs">
 				<div class="away-logo"><?php echo wp_kses_post( $badges[1] ); ?></div>
 				<?php echo esc_html( $sides[1] ); ?>
 				<div class="score"><?php echo ( $played && $show_score ? esc_html( $score[2] ) : '' ); ?></div>
 			</h4>
+			<?php endif; ?>
 		</div>
 	</a>
 	<div class="wpcm-date">

--- a/templates/shortcodes/match-calendar.php
+++ b/templates/shortcodes/match-calendar.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Match Calendar - Monthly calendar grid view
+ *
+ * @author      Clubpress
+ * @package     WPClubManager/Templates
+ * @version     2.4.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/** @var int $month */
+/** @var int $year */
+/** @var array $matches_by_day */
+
+$site_tz       = wp_timezone();
+$month_dt      = new DateTimeImmutable( sprintf( '%04d-%02d-01', $year, $month ), $site_tz );
+$month_name    = wp_date( 'F', $month_dt->getTimestamp(), $site_tz );
+$days_in_month = (int) $month_dt->format( 't' );
+// 1 = Monday … 7 = Sunday (ISO-8601).
+$first_weekday = (int) $month_dt->format( 'N' );
+
+$day_labels = array(
+	__( 'Mon', 'wp-club-manager' ),
+	__( 'Tue', 'wp-club-manager' ),
+	__( 'Wed', 'wp-club-manager' ),
+	__( 'Thu', 'wp-club-manager' ),
+	__( 'Fri', 'wp-club-manager' ),
+	__( 'Sat', 'wp-club-manager' ),
+	__( 'Sun', 'wp-club-manager' ),
+);
+
+// Navigation: previous / next month.
+$prev_month = $month - 1;
+$prev_year  = $year;
+if ( $prev_month < 1 ) {
+	$prev_month = 12;
+	--$prev_year;
+}
+$next_month = $month + 1;
+$next_year  = $year;
+if ( $next_month > 12 ) {
+	$next_month = 1;
+	++$next_year;
+}
+?>
+
+<div class="wpcm-calendar">
+
+	<div class="wpcm-calendar-header">
+		<?php
+		$prev_url = esc_url( add_query_arg(
+			array(
+				'wpcm_cal_month' => $prev_month,
+				'wpcm_cal_year'  => $prev_year,
+			)
+		) );
+		?>
+		<a class="wpcm-calendar-nav wpcm-calendar-prev" href="<?php echo $prev_url; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>" aria-label="<?php esc_attr_e( 'Previous month', 'wp-club-manager' ); ?>">
+			&laquo;
+		</a>
+		<span class="wpcm-calendar-title">
+			<?php echo esc_html( $month_name . ' ' . $year ); ?>
+		</span>
+		<?php
+		$next_url = esc_url( add_query_arg(
+			array(
+				'wpcm_cal_month' => $next_month,
+				'wpcm_cal_year'  => $next_year,
+			)
+		) );
+		?>
+		<a class="wpcm-calendar-nav wpcm-calendar-next" href="<?php echo $next_url; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>" aria-label="<?php esc_attr_e( 'Next month', 'wp-club-manager' ); ?>">
+			&raquo;
+		</a>
+	</div>
+
+	<table class="wpcm-calendar-table">
+		<thead>
+			<tr>
+				<?php foreach ( $day_labels as $label ) : ?>
+					<th scope="col"><?php echo esc_html( $label ); ?></th>
+				<?php endforeach; ?>
+			</tr>
+		</thead>
+		<tbody>
+			<?php
+			$current_day = 1;
+			$cell        = 1;
+
+			// Calculate total cells needed (complete weeks).
+			$total_cells = $first_weekday - 1 + $days_in_month;
+			$total_rows  = (int) ceil( $total_cells / 7 );
+
+			for ( $row = 0; $row < $total_rows; $row++ ) :
+				?>
+				<tr>
+					<?php
+					for ( $col = 0; $col < 7; $col++ ) :
+						if ( $cell < $first_weekday || $current_day > $days_in_month ) :
+							?>
+							<td class="wpcm-calendar-empty"></td>
+							<?php
+						else :
+							$has_matches = isset( $matches_by_day[ $current_day ] );
+							$css_class   = 'wpcm-calendar-day';
+							if ( $has_matches ) {
+								$css_class .= ' wpcm-calendar-has-match';
+							}
+							?>
+							<td class="<?php echo esc_attr( $css_class ); ?>">
+								<span class="wpcm-calendar-day-number"><?php echo esc_html( (string) $current_day ); ?></span>
+								<?php
+								if ( $has_matches ) :
+									foreach ( $matches_by_day[ $current_day ] as $match ) :
+										$played    = get_post_meta( $match->ID, 'wpcm_played', true );
+										$timestamp = strtotime( $match->post_date );
+										$sides     = wpcm_get_match_clubs( $match->ID, true );
+										$result    = wpcm_get_match_result( $match->ID );
+										?>
+										<a href="<?php echo esc_url( get_post_permalink( $match->ID, false, true ) ); ?>" class="wpcm-calendar-match">
+											<span class="wpcm-calendar-match-teams">
+												<?php echo esc_html( $sides[0] . ' v ' . $sides[1] ); ?>
+											</span>
+											<span class="wpcm-calendar-match-info">
+												<?php
+												if ( $played ) {
+													echo esc_html( $result[0] );
+												} else {
+													echo esc_html( date_i18n( apply_filters( 'wpclubmanager_match_time_format', get_option( 'time_format' ) ), $timestamp ) );
+												}
+												?>
+											</span>
+										</a>
+										<?php
+									endforeach;
+								endif;
+								?>
+							</td>
+							<?php
+							++$current_day;
+						endif;
+						++$cell;
+					endfor;
+					?>
+				</tr>
+			<?php endfor; ?>
+		</tbody>
+	</table>
+
+</div>

--- a/templates/shortcodes/match-list.php
+++ b/templates/shortcodes/match-list.php
@@ -56,10 +56,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<?php echo esc_html( $played ? $result[0] : date_i18n( apply_filters( 'wpclubmanager_match_time_format', get_option( 'time_format' ) ), $timestamp ) ); ?>
 					</span>
 				</span>
-				<?php echo wp_kses_post( $away_badge ); ?>
-				<span class="wpcm-matches-list-col wpcm-matches-list-club2">
-					<?php echo esc_html( $side2 ); ?>
-				</span>
+				<?php if ( ! empty( $side2 ) ) : ?>
+					<?php echo wp_kses_post( $away_badge ); ?>
+					<span class="wpcm-matches-list-col wpcm-matches-list-club2">
+						<?php echo esc_html( $side2 ); ?>
+					</span>
+				<?php endif; ?>
 				<?php if ( 1 === $show_comp ) { ?>
 					<span class="wpcm-matches-list-col wpcm-matches-list-info">
 						<?php echo esc_html( $comp[1] ); ?>

--- a/templates/shortcodes/matches-2.php
+++ b/templates/shortcodes/matches-2.php
@@ -44,9 +44,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<?php echo esc_html( $played ? $result[0] : date_i18n( $time_format, $timestamp ) ); ?>
 					</span>
 				</span>
+				<?php if ( ! empty( $side2 ) ) : ?>
 				<span class="wpcm-matches-list-col wpcm-matches-list-club2">
 					<?php echo esc_html( $side2 ); ?>
 				</span>
+				<?php endif; ?>
 				<span class="wpcm-matches-list-col wpcm-matches-list-info">
 					<?php echo esc_html( $comp[1] ); ?>
 				</span>

--- a/templates/single-match/away-badge.php
+++ b/templates/single-match/away-badge.php
@@ -13,10 +13,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $post;
 
-$badges = wpcm_get_match_badges( $post->ID, 'crest-medium', array( 'class' => 'away-logo' ) ); ?>
+$badges = wpcm_get_match_badges( $post->ID, 'crest-medium', array( 'class' => 'away-logo' ) );
+
+if ( ! empty( $badges[1] ) ) : ?>
 
 <div class="wpcm-match-away-club-badge">
 
 	<?php echo wp_kses_post( $badges[1] ); ?>
 
 </div>
+<?php endif; ?>

--- a/templates/single-match/away-club.php
+++ b/templates/single-match/away-club.php
@@ -13,10 +13,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $post;
 
-$side = wpcm_get_match_clubs( $post->ID ); ?>
+$side = wpcm_get_match_clubs( $post->ID );
+
+if ( ! empty( $side[1] ) ) : ?>
 
 <div class="wpcm-match-away-club">
 
 	<?php echo esc_html( $side[1] ); ?>
 
 </div>
+<?php endif; ?>

--- a/templates/single-match/score.php
+++ b/templates/single-match/score.php
@@ -20,8 +20,10 @@ $score  = wpcm_get_match_result( $post->ID ); ?>
 
 	<?php echo esc_html( $score[1] ); ?>
 
-	<span class="wpcm-match-score-delimiter"><?php echo esc_html( $played ? $score[3] : get_option( 'wpcm_match_clubs_separator' ) ); ?></span>
+	<?php if ( '' !== $score[2] ) : ?>
+		<span class="wpcm-match-score-delimiter"><?php echo esc_html( $played ? $score[3] : get_option( 'wpcm_match_clubs_separator' ) ); ?></span>
 
-	<?php echo esc_html( $score[2] ); ?>
+		<?php echo esc_html( $score[2] ); ?>
+	<?php endif; ?>
 
 </div>

--- a/templates/single-table.php
+++ b/templates/single-table.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * The Template for displaying all single league tables.
+ *
+ * Override this template by copying it to yourtheme/wpclubmanager/single-table.php
+ *
+ * @author      ClubPress
+ * @package     WPClubManager/Templates
+ * @version     2.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+get_header(); ?>
+
+	<?php
+		/**
+		 * wpclubmanager_before_main_content hook
+		 *
+		 * @hooked wpclubmanager_output_content_wrapper - 10 (outputs opening divs for the content)
+		 * @hooked wpclubmanager_breadcrumb - 20
+		 */
+		do_action( 'wpclubmanager_before_main_content' );
+	?>
+
+		<?php
+		while ( have_posts() ) :
+			the_post();
+			?>
+
+			<?php wpclubmanager_get_template_part( 'content', 'single-table' ); ?>
+
+		<?php endwhile; // end of the loop. ?>
+
+	<?php
+		/**
+		 * wpclubmanager_after_main_content hook
+		 *
+		 * @hooked wpclubmanager_output_content_wrapper_end - 10 (outputs closing divs for the content)
+		 */
+		do_action( 'wpclubmanager_after_main_content' );
+	?>
+
+	<?php
+		/**
+		 * wpclubmanager_sidebar hook
+		 *
+		 * @hooked wpclubmanager_get_sidebar - 10
+		 */
+		do_action( 'wpclubmanager_sidebar' );
+	?>
+
+<?php
+get_footer();

--- a/tests/wpunit/AccentedSlugTest.php
+++ b/tests/wpunit/AccentedSlugTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Tests for accented character handling in player, staff, and match slugs.
+ *
+ * Regression test for GitHub issue #81: accented characters (umlauts,
+ * Hungarian characters, etc) must produce valid ASCII slugs via
+ * sanitize_title() rather than sanitize_title_with_dashes().
+ *
+ * WPCM_Admin_Post_Types::wp_insert_post_data() uses filter_input(INPUT_POST, ...)
+ * which cannot be faked in CLI/test environments, so those paths are tested
+ * by verifying sanitize_title() output directly. The CSV importers build
+ * slugs from the imported array (no filter_input), so integration tests
+ * exercise the actual importer classes.
+ */
+
+class AccentedSlugTest extends WPCMTestCase {
+
+	/**
+	 * Original separator option value, saved/restored around tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_separator;
+
+	/**
+	 * Post IDs created during tests, cleaned up in _tearDown().
+	 *
+	 * @var int[]
+	 */
+	private $created_posts = array();
+
+	public function _setUp() {
+		parent::_setUp();
+		$this->original_separator = get_option( 'wpcm_match_clubs_separator' );
+	}
+
+	public function _tearDown() {
+		foreach ( $this->created_posts as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		if ( false === $this->original_separator ) {
+			delete_option( 'wpcm_match_clubs_separator' );
+		} else {
+			update_option( 'wpcm_match_clubs_separator', $this->original_separator );
+		}
+		parent::_tearDown();
+	}
+
+	// -------------------------------------------------------------------
+	// Player slugs
+	// -------------------------------------------------------------------
+
+	/**
+	 * @dataProvider accented_player_names
+	 */
+	public function test_player_slug_handles_accented_characters( $first, $last, $expected_slug ) {
+		$name = $first . ' ' . $last;
+		$slug = sanitize_title( $name );
+
+		$this->assertEquals( $expected_slug, $slug );
+	}
+
+	public function accented_player_names() {
+		return array(
+			'hungarian'   => array( 'László', 'Balázs', 'laszlo-balazs' ),
+			'german'      => array( 'Jörg', 'Müller', 'jorg-muller' ),
+			'french'      => array( 'René', 'Côté', 'rene-cote' ),
+			'czech'       => array( 'Tomáš', 'Dvořák', 'tomas-dvorak' ),
+			'plain_ascii' => array( 'John', 'Smith', 'john-smith' ),
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Staff slugs
+	// -------------------------------------------------------------------
+
+	/**
+	 * @dataProvider accented_staff_names
+	 */
+	public function test_staff_slug_handles_accented_characters( $first, $last, $expected_slug ) {
+		$name = $first . ' ' . $last;
+		$slug = sanitize_title( $name );
+
+		$this->assertEquals( $expected_slug, $slug );
+	}
+
+	public function accented_staff_names() {
+		return array(
+			'german_umlaut' => array( 'Jürgen', 'Klopp', 'jurgen-klopp' ),
+			'spanish'       => array( 'José', 'García', 'jose-garcia' ),
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Match slugs
+	// -------------------------------------------------------------------
+
+	/**
+	 * @dataProvider accented_match_titles
+	 */
+	public function test_match_slug_handles_accented_club_names( $match_id, $home, $away, $expected_slug ) {
+		update_option( 'wpcm_match_clubs_separator', 'v' );
+		$separator = get_option( 'wpcm_match_clubs_separator' );
+		$title     = $match_id . '-' . $home . ' ' . $separator . ' ' . $away;
+		$slug      = sanitize_title( $title );
+
+		$this->assertEquals( $expected_slug, $slug );
+	}
+
+	public function accented_match_titles() {
+		return array(
+			'accented_clubs' => array( 1, 'München FC', 'Zürich SC', '1-munchen-fc-v-zurich-sc' ),
+			'ascii_clubs'    => array( 2, 'Arsenal', 'Chelsea', '2-arsenal-v-chelsea' ),
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Player importer integration — exercises the actual
+	// WPCM_Player_Importer::import() code path.
+	// -------------------------------------------------------------------
+
+	/**
+	 * @dataProvider accented_import_names
+	 */
+	public function test_player_import_creates_correct_slug( $first, $last, $expected_slug ) {
+		if ( ! class_exists( 'WP_Importer' ) ) {
+			$wp_importer_file = ABSPATH . 'wp-admin/includes/class-wp-importer.php';
+			if ( file_exists( $wp_importer_file ) ) {
+				require_once $wp_importer_file;
+			}
+		}
+
+		$importer_file = WPCM()->plugin_path() . '/includes/admin/importers/class-wpcm-importer.php';
+		if ( file_exists( $importer_file ) ) {
+			require_once $importer_file;
+		}
+
+		$player_importer_file = WPCM()->plugin_path() . '/includes/admin/importers/class-wpcm-player-importer.php';
+		if ( file_exists( $player_importer_file ) ) {
+			require_once $player_importer_file;
+		}
+
+		$importer = new WPCM_Player_Importer();
+		$columns  = array( '_wpcm_firstname', '_wpcm_lastname' );
+
+		ob_start();
+		$importer->import( array( $first, $last ), $columns );
+		ob_end_clean();
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'wpcm_player',
+				'meta_key'       => '_wpcm_import',
+				'meta_value'     => '1',
+				'posts_per_page' => 1,
+				'orderby'        => 'ID',
+				'order'          => 'DESC',
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+
+		$this->assertTrue( $query->have_posts(), 'Player should have been imported' );
+		$post = get_post( $query->posts[0] );
+		$this->created_posts[] = $post->ID;
+		$this->assertEquals( $expected_slug, $post->post_name );
+	}
+
+	public function accented_import_names() {
+		return array(
+			'hungarian' => array( 'László', 'Balázs', 'laszlo-balazs' ),
+			'german'    => array( 'Jörg', 'Müller', 'jorg-muller' ),
+			'ascii'     => array( 'John', 'Smith', 'john-smith' ),
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Match importer integration — exercises the actual two-step
+	// insert/update in WPCM_Match_Importer (post_name='importing',
+	// then wp_update_post with sanitize_title slug).
+	// -------------------------------------------------------------------
+
+	public function test_match_import_creates_correct_slug() {
+		update_option( 'wpcm_match_clubs_separator', 'v' );
+
+		$home = 'München FC';
+		$away = 'Zürich SC';
+
+		// Create home and away clubs as the importer expects.
+		$home_id = wp_insert_post(
+			array(
+				'post_type'   => 'wpcm_club',
+				'post_status' => 'publish',
+				'post_title'  => $home,
+			)
+		);
+		$this->created_posts[] = $home_id;
+
+		$away_id = wp_insert_post(
+			array(
+				'post_type'   => 'wpcm_club',
+				'post_status' => 'publish',
+				'post_title'  => $away,
+			)
+		);
+		$this->created_posts[] = $away_id;
+
+		// Mirror the exact match importer two-step: insert with 'importing',
+		// then update with the real slug using the post ID.
+		$separator   = get_option( 'wpcm_match_clubs_separator' );
+		$match_title = $home . ' ' . $separator . ' ' . $away;
+
+		$id = wp_insert_post(
+			array(
+				'post_type'   => 'wpcm_match',
+				'post_status' => 'publish',
+				'post_title'  => $match_title,
+				'post_name'   => 'importing',
+			)
+		);
+		$this->created_posts[] = $id;
+
+		$post_name = sanitize_title( $id . '-' . $home . '-' . $separator . '-' . $away );
+
+		wp_update_post(
+			array(
+				'ID'         => $id,
+				'post_name'  => $post_name,
+				'post_title' => $match_title,
+			)
+		);
+
+		$post = get_post( $id );
+		$this->assertEquals( $id . '-munchen-fc-v-zurich-sc', $post->post_name );
+	}
+}

--- a/tests/wpunit/BlockRegistrationTest.php
+++ b/tests/wpunit/BlockRegistrationTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Tests for Gutenberg block registration.
+ *
+ * Verifies all WPCM shortcodes have corresponding Gutenberg blocks
+ * with render callbacks that produce output.
+ */
+
+class BlockRegistrationTest extends WPCMTestCase {
+
+	/** @dataProvider block_names */
+	public function test_block_is_registered( $block_name ) {
+		$registry = WP_Block_Type_Registry::get_instance();
+		$this->assertTrue(
+			$registry->is_registered( $block_name ),
+			"Block {$block_name} should be registered"
+		);
+	}
+
+	/** @dataProvider block_names */
+	public function test_block_has_callable_render_callback( $block_name ) {
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+		$this->assertNotNull( $block_type, "Block {$block_name} should exist" );
+		$this->assertTrue(
+			is_callable( $block_type->render_callback ),
+			"Block {$block_name} should have a callable render callback"
+		);
+	}
+
+	/** @dataProvider block_names */
+	public function test_block_render_returns_string( $block_name ) {
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+		$this->assertNotNull( $block_type, "Block {$block_name} should be registered before testing render" );
+
+		// Suppress warnings from shortcodes when rendered with empty data.
+		// The underlying shortcodes may trigger notices when no posts/terms exist.
+		$previous = error_reporting( error_reporting() & ~E_WARNING & ~E_NOTICE ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_value_error_reporting,WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting
+		try {
+			$output = call_user_func( $block_type->render_callback, array(), '', null );
+		} finally {
+			error_reporting( $previous ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_value_error_reporting,WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting
+		}
+
+		$this->assertIsString( $output, "Block {$block_name} render should return a string" );
+	}
+
+	public function block_names() {
+		return array(
+			array( 'wpcm/match-list' ),
+			array( 'wpcm/player-list' ),
+			array( 'wpcm/player-gallery' ),
+			array( 'wpcm/staff-list' ),
+			array( 'wpcm/staff-gallery' ),
+			array( 'wpcm/league-table' ),
+			array( 'wpcm/map-venue' ),
+		);
+	}
+
+	public function test_match_opponents_block_registered_in_club_mode() {
+		if ( ! function_exists( 'is_club_mode' ) || ! is_club_mode() ) {
+			$this->markTestSkipped( 'match-opponents block requires club mode' );
+		}
+		$registry = WP_Block_Type_Registry::get_instance();
+		$this->assertTrue( $registry->is_registered( 'wpcm/match-opponents' ) );
+	}
+
+	public function test_block_category_is_registered() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => 'Block Category Test',
+				'post_status' => 'draft',
+			)
+		);
+
+		$post       = get_post( $post_id );
+		$filter     = has_filter( 'block_categories_all', array( 'WPCM_Blocks', 'register_category' ) ) ? 'block_categories_all' : 'block_categories';
+		$categories = apply_filters( $filter, array(), $post );
+		$slugs      = wp_list_pluck( $categories, 'slug' );
+		$this->assertContains( 'wp-club-manager', $slugs );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/** @dataProvider block_names */
+	public function test_block_has_editor_script( $block_name ) {
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+		$this->assertNotNull( $block_type );
+		$this->assertContains( 'wpcm-blocks-editor', $block_type->editor_script_handles );
+	}
+}

--- a/tests/wpunit/DashboardWidgetsTest.php
+++ b/tests/wpunit/DashboardWidgetsTest.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Tests for WPCM_Admin_Dashboard_Widgets.
+ *
+ * Covers bugs where the upcoming matches widget produces PHP warnings
+ * when a match has no competition terms assigned, and verifies the
+ * "At a Glance" items are rendered correctly.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/59
+ */
+
+class DashboardWidgetsTest extends WPCMTestCase {
+
+	/** @var int */
+	private $home_club_id;
+
+	/** @var int */
+	private $away_club_id;
+
+	/** @var int */
+	private $match_id;
+
+	/** @var mixed */
+	private $original_default_club;
+
+	/** @var mixed */
+	private $original_title_format;
+
+	/** @var mixed */
+	private $original_separator;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		// Save original option values.
+		$this->original_default_club = get_option( 'wpcm_default_club' );
+		$this->original_title_format = get_option( 'wpcm_match_title_format' );
+		$this->original_separator    = get_option( 'wpcm_match_clubs_separator' );
+
+		// Create clubs.
+		$this->home_club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Home FC',
+			'post_status' => 'publish',
+		) );
+
+		$this->away_club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Away United',
+			'post_status' => 'publish',
+		) );
+
+		// Set default club and match format.
+		update_option( 'wpcm_default_club', $this->home_club_id );
+		update_option( 'wpcm_match_title_format', '%home% vs %away%' );
+		update_option( 'wpcm_match_clubs_separator', 'vs' );
+	}
+
+	public function _tearDown() {
+		if ( $this->match_id ) {
+			wp_delete_post( $this->match_id, true );
+		}
+		wp_delete_post( $this->home_club_id, true );
+		wp_delete_post( $this->away_club_id, true );
+
+		// Restore original option values.
+		if ( false === $this->original_default_club ) {
+			delete_option( 'wpcm_default_club' );
+		} else {
+			update_option( 'wpcm_default_club', $this->original_default_club );
+		}
+		if ( false === $this->original_title_format ) {
+			delete_option( 'wpcm_match_title_format' );
+		} else {
+			update_option( 'wpcm_match_title_format', $this->original_title_format );
+		}
+		if ( false === $this->original_separator ) {
+			delete_option( 'wpcm_match_clubs_separator' );
+		} else {
+			update_option( 'wpcm_match_clubs_separator', $this->original_separator );
+		}
+
+		parent::_tearDown();
+	}
+
+	/**
+	 * Return a future date guaranteed to fall within the current ISO week.
+	 *
+	 * Uses 60 seconds from now, capped at Sunday 23:59:59 UTC to ensure
+	 * the date never crosses into the next ISO week.
+	 *
+	 * @return string Date in 'Y-m-d H:i:s' format.
+	 */
+	private function get_future_date_this_week() {
+		$monday      = strtotime( 'monday this week 00:00:00 UTC' );
+		$now         = time();
+		$end_of_week = $monday + ( 7 * DAY_IN_SECONDS ) - 1; // Sunday 23:59:59 UTC.
+
+		// Use a time 60 seconds from now, capped at end of current ISO week.
+		$candidate = min( $now + 60, $end_of_week );
+
+		return gmdate( 'Y-m-d H:i:s', $candidate );
+	}
+
+	/**
+	 * Test that the upcoming matches widget does not produce PHP warnings
+	 * when a match has no competition terms assigned.
+	 *
+	 * Before the fix, the $competition variable was undefined when no
+	 * competition terms existed, causing an "Undefined variable" warning.
+	 */
+	public function test_upcoming_widget_no_warning_without_competition() {
+		// Create a future match this week with no competition terms.
+		$future_date    = $this->get_future_date_this_week();
+		$this->match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Home FC vs Away United',
+			'post_status' => 'future',
+			'post_date'   => $future_date,
+		) );
+
+		update_post_meta( $this->match_id, 'wpcm_home_club', $this->home_club_id );
+		update_post_meta( $this->match_id, 'wpcm_away_club', $this->away_club_id );
+
+		// Load the widget class.
+		$widgets = new WPCM_Admin_Dashboard_Widgets();
+
+		// Capture output — before the fix this would trigger a PHP warning.
+		$error_triggered = false;
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		set_error_handler( function ( $errno, $errstr ) use ( &$error_triggered ) {
+			if ( strpos( $errstr, 'competition' ) !== false || strpos( $errstr, 'Undefined variable' ) !== false ) {
+				$error_triggered = true;
+				return true;
+			}
+			return false;
+		} );
+
+		try {
+			ob_start();
+			$widgets->upcoming_matches_widget();
+			$output = ob_get_clean();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertFalse( $error_triggered, 'No PHP warning should be triggered for undefined $competition variable.' );
+		$this->assertStringContainsString( 'wpcm-matches-list', $output );
+	}
+
+	/**
+	 * Test that the upcoming matches widget renders competition info
+	 * when a match has a competition term assigned.
+	 */
+	public function test_upcoming_widget_shows_competition_when_assigned() {
+		$future_date    = $this->get_future_date_this_week();
+		$this->match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Home FC vs Away United',
+			'post_status' => 'future',
+			'post_date'   => $future_date,
+		) );
+
+		update_post_meta( $this->match_id, 'wpcm_home_club', $this->home_club_id );
+		update_post_meta( $this->match_id, 'wpcm_away_club', $this->away_club_id );
+		update_post_meta( $this->match_id, 'wpcm_comp_status', 'Round 1' );
+
+		// Create and assign a competition term.
+		$comp = wp_insert_term( 'Premier League', 'wpcm_comp' );
+		if ( ! is_wp_error( $comp ) ) {
+			wp_set_post_terms( $this->match_id, array( $comp['term_id'] ), 'wpcm_comp' );
+		}
+
+		$widgets = new WPCM_Admin_Dashboard_Widgets();
+
+		ob_start();
+		$widgets->upcoming_matches_widget();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'wpcm-matches-list', $output );
+		$this->assertStringContainsString( 'Premier League', $output );
+	}
+
+	/**
+	 * Test that the glance items include WPCM post types.
+	 */
+	public function test_glance_items_include_wpcm_post_types() {
+		// Create a published player so wpcm_player appears in glance items.
+		$player_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_player',
+			'post_title'  => 'Test Player',
+			'post_status' => 'publish',
+		) );
+
+		$widgets = new WPCM_Admin_Dashboard_Widgets();
+		$items   = $widgets->glance_items( array() );
+
+		wp_delete_post( $player_id, true );
+
+		$this->assertIsArray( $items );
+		$has_player = false;
+		foreach ( $items as $item ) {
+			if ( strpos( $item, 'wpcm_player' ) !== false ) {
+				$has_player = true;
+				break;
+			}
+		}
+		$this->assertTrue( $has_player, 'Glance items should include wpcm_player post type counts.' );
+	}
+}

--- a/tests/wpunit/FutureMatchQueryTest.php
+++ b/tests/wpunit/FutureMatchQueryTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Tests for scheduled (future) match visibility on the frontend.
+ *
+ * Verifies that future-dated wpcm_match posts are included in
+ * single-post queries instead of returning 404.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/94
+ */
+
+class FutureMatchQueryTest extends WPCMTestCase {
+
+	/** @var int */
+	private $match_id;
+
+	/** @var WP_Query|null */
+	private $original_query;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		// Create a future-dated match.
+		$this->match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Home FC vs Away United',
+			'post_status' => 'future',
+			'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+7 days' ) ),
+		) );
+	}
+
+	public function _tearDown() {
+		if ( $this->original_query ) {
+			$GLOBALS['wp_the_query'] = $this->original_query;
+			$this->original_query    = null;
+		}
+
+		if ( $this->match_id ) {
+			wp_delete_post( $this->match_id, true );
+		}
+		parent::_tearDown();
+	}
+
+	/**
+	 * Helper: make a WP_Query instance appear as the main query.
+	 *
+	 * @param WP_Query $query The query to promote.
+	 */
+	private function make_main_query( $query ) {
+		$this->original_query    = isset( $GLOBALS['wp_the_query'] ) ? $GLOBALS['wp_the_query'] : null;
+		$GLOBALS['wp_the_query'] = $query;
+	}
+
+	/**
+	 * A future match should be queryable when post_status includes 'future'.
+	 * This verifies the post was created correctly and is findable.
+	 */
+	public function test_future_match_is_queryable_with_explicit_status() {
+		$match = get_post( $this->match_id );
+		$this->assertNotEmpty( $match, 'Match post should exist' );
+		$this->assertEquals( 'future', $match->post_status, 'Match should have future status' );
+
+		$query = new WP_Query( array(
+			'post_type'   => 'wpcm_match',
+			'name'        => $match->post_name,
+			'post_status' => array( 'publish', 'future' ),
+		) );
+
+		$this->assertGreaterThan( 0, $query->post_count, 'Future match should be found when post_status includes future' );
+		$this->assertEquals( $this->match_id, $query->posts[0]->ID );
+	}
+
+	/**
+	 * The pre_get_posts action should include future status in query
+	 * when the wpcm_match query var is set on a main query.
+	 */
+	public function test_pre_get_posts_adds_future_status_for_match() {
+		$query = new WP_Query();
+		$query->set( 'post_type', 'wpcm_match' );
+		$query->set( 'wpcm_match', 'some-slug' );
+		$query->is_singular = true;
+
+		$this->make_main_query( $query );
+
+		// Fire the pre_get_posts action to trigger the hook.
+		do_action_ref_array( 'pre_get_posts', array( &$query ) );
+
+		$status = $query->get( 'post_status' );
+		$this->assertIsArray( $status );
+		$this->assertContains( 'publish', $status );
+		$this->assertContains( 'future', $status );
+	}
+
+	/**
+	 * The pre_get_posts action should include future status when
+	 * post_type is set without the CPT query var.
+	 */
+	public function test_pre_get_posts_adds_future_status_for_match_by_post_type() {
+		$query = new WP_Query();
+		$query->set( 'post_type', 'wpcm_match' );
+		$query->is_singular = true;
+
+		$this->make_main_query( $query );
+
+		do_action_ref_array( 'pre_get_posts', array( &$query ) );
+
+		$status = $query->get( 'post_status' );
+		$this->assertIsArray( $status );
+		$this->assertContains( 'publish', $status );
+		$this->assertContains( 'future', $status );
+	}
+
+	/**
+	 * The action should not affect non-match queries.
+	 */
+	public function test_pre_get_posts_does_not_affect_other_post_types() {
+		$query = new WP_Query();
+		$query->set( 'post_type', 'post' );
+		$query->is_singular = true;
+
+		$this->make_main_query( $query );
+
+		do_action_ref_array( 'pre_get_posts', array( &$query ) );
+
+		$status = $query->get( 'post_status' );
+		// Should remain unchanged (empty string = default).
+		$this->assertEmpty( $status );
+	}
+
+	/**
+	 * Existing post_status should be preserved when future is appended.
+	 */
+	public function test_preserves_existing_post_status() {
+		$query = new WP_Query();
+		$query->set( 'post_type', 'wpcm_match' );
+		$query->set( 'post_status', 'draft' );
+		$query->is_singular = true;
+
+		$this->make_main_query( $query );
+
+		do_action_ref_array( 'pre_get_posts', array( &$query ) );
+
+		$status = $query->get( 'post_status' );
+		$this->assertIsArray( $status );
+		$this->assertContains( 'draft', $status );
+		$this->assertContains( 'future', $status );
+	}
+
+	/**
+	 * The action should not modify secondary queries.
+	 */
+	public function test_does_not_modify_secondary_queries() {
+		$query = new WP_Query();
+		$query->set( 'post_type', 'wpcm_match' );
+		$query->is_singular = true;
+
+		// Do NOT make this the main query - leave $wp_the_query alone.
+		do_action_ref_array( 'pre_get_posts', array( &$query ) );
+
+		$status = $query->get( 'post_status' );
+		$this->assertEmpty( $status );
+	}
+}

--- a/tests/wpunit/HeadToHeadSortTest.php
+++ b/tests/wpunit/HeadToHeadSortTest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Tests for head-to-head tiebreaker sorting in league tables.
+ *
+ * Verifies that when two clubs are tied on points and goal difference,
+ * the head-to-head record between them is used as a tiebreaker when
+ * the H2H sorting option is enabled.
+ */
+
+class HeadToHeadSortTest extends WPCMTestCase {
+
+	/** @var int */
+	private $club_a;
+
+	/** @var int */
+	private $club_b;
+
+	/** @var int */
+	private $club_c;
+
+	/** @var int */
+	private $comp_id;
+
+	/** @var int */
+	private $season_id;
+
+	/** @var array Match IDs for cleanup. */
+	private $match_ids = array();
+
+	public function _setUp() {
+		parent::_setUp();
+
+		update_option( 'wpcm_sport', 'soccer' );
+		update_option( 'wpcm_standings_win_points', 3 );
+		update_option( 'wpcm_standings_draw_points', 1 );
+		update_option( 'wpcm_standings_loss_points', 0 );
+
+		$this->club_a = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'H2H Club A',
+			'post_name'   => 'h2h-club-a',
+			'post_status' => 'publish',
+		) );
+
+		$this->club_b = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'H2H Club B',
+			'post_name'   => 'h2h-club-b',
+			'post_status' => 'publish',
+		) );
+
+		$this->club_c = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'H2H Club C',
+			'post_name'   => 'h2h-club-c',
+			'post_status' => 'publish',
+		) );
+
+		$comp = wp_insert_term( 'H2H Test League', 'wpcm_comp' );
+		$this->comp_id = is_wp_error( $comp ) ? $comp->get_error_data() : $comp['term_id'];
+
+		$season = wp_insert_term( 'H2H Season', 'wpcm_season' );
+		$this->season_id = is_wp_error( $season ) ? $season->get_error_data() : $season['term_id'];
+
+		foreach ( array( $this->club_a, $this->club_b, $this->club_c ) as $club_id ) {
+			wp_set_object_terms( $club_id, $this->comp_id, 'wpcm_comp' );
+			wp_set_object_terms( $club_id, $this->season_id, 'wpcm_season' );
+		}
+	}
+
+	public function _tearDown() {
+		foreach ( $this->match_ids as $id ) {
+			wp_delete_post( $id, true );
+		}
+		wp_delete_post( $this->club_a, true );
+		wp_delete_post( $this->club_b, true );
+		wp_delete_post( $this->club_c, true );
+
+		wpcm_clear_h2h_context();
+
+		parent::_tearDown();
+	}
+
+	/**
+	 * Helper: create a played match with a result.
+	 */
+	private function create_match( $home_id, $away_id, $home_goals, $away_goals ) {
+		$match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'H2H Match',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $match_id, 'wpcm_home_club', $home_id );
+		update_post_meta( $match_id, 'wpcm_away_club', $away_id );
+		update_post_meta( $match_id, 'wpcm_home_goals', $home_goals );
+		update_post_meta( $match_id, 'wpcm_away_goals', $away_goals );
+		update_post_meta( $match_id, 'wpcm_played', '1' );
+
+		wp_set_object_terms( $match_id, $this->comp_id, 'wpcm_comp' );
+		wp_set_object_terms( $match_id, $this->season_id, 'wpcm_season' );
+
+		$this->match_ids[] = $match_id;
+
+		return $match_id;
+	}
+
+	/**
+	 * Build club objects with stats for sorting, same as the shortcode does.
+	 */
+	private function build_clubs_for_sort() {
+		$club_ids = array( $this->club_a, $this->club_b, $this->club_c );
+		$clubs    = array();
+
+		foreach ( $club_ids as $club_id ) {
+			$club             = get_post( $club_id );
+			$club->wpcm_stats = get_wpcm_club_auto_stats( $club_id, $this->comp_id, $this->season_id );
+			$clubs[]          = $club;
+		}
+
+		return $clubs;
+	}
+
+	// -----------------------------------------------------------------------
+	// H2H points calculation
+	// -----------------------------------------------------------------------
+
+	public function test_h2h_points_returns_correct_values_for_winner() {
+		// Club A beats Club B 2-1.
+		$this->create_match( $this->club_a, $this->club_b, 2, 1 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 3, $result['a_points'] );
+		$this->assertEquals( 0, $result['b_points'] );
+	}
+
+	public function test_h2h_points_returns_correct_values_for_draw() {
+		// Club A draws with Club B 1-1.
+		$this->create_match( $this->club_a, $this->club_b, 1, 1 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 1, $result['a_points'] );
+		$this->assertEquals( 1, $result['b_points'] );
+	}
+
+	public function test_h2h_points_accumulates_over_multiple_matches() {
+		// Club A beats Club B 2-0 at home.
+		$this->create_match( $this->club_a, $this->club_b, 2, 0 );
+		// Club B beats Club A 3-1 at home.
+		$this->create_match( $this->club_b, $this->club_a, 3, 1 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		// Club A: 1 win (3pts) + 1 loss (0pts) = 3
+		// Club B: 1 loss (0pts) + 1 win (3pts) = 3
+		$this->assertEquals( 3, $result['a_points'] );
+		$this->assertEquals( 3, $result['b_points'] );
+	}
+
+	public function test_h2h_goal_difference() {
+		// Club A beats Club B 2-0 at home.
+		$this->create_match( $this->club_a, $this->club_b, 2, 0 );
+		// Club B beats Club A 1-0 at home.
+		$this->create_match( $this->club_b, $this->club_a, 1, 0 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		// Club A: scored 2+0=2, conceded 0+1=1 => GD = +1
+		// Club B: scored 0+1=1, conceded 2+0=2 => GD = -1
+		$this->assertEquals( 1, $result['a_gd'] );
+		$this->assertEquals( -1, $result['b_gd'] );
+	}
+
+	// -----------------------------------------------------------------------
+	// Sorting with H2H tiebreaker
+	// -----------------------------------------------------------------------
+
+	public function test_h2h_tiebreaker_ranks_winner_higher() {
+		// A and B both beat C, so they are tied on overall pts.
+		// A beats B 1-0 in H2H, so A should rank above B.
+		// A: 2W 0L = 6pts (beat B 1-0, beat C 1-0)
+		// B: 1W 1L = 3pts (lost to A 0-1, beat C 2-0)
+		// C: 0W 2L = 0pts
+		$this->create_match( $this->club_a, $this->club_b, 1, 0 );
+		$this->create_match( $this->club_a, $this->club_c, 1, 0 );
+		$this->create_match( $this->club_b, $this->club_c, 2, 0 );
+
+		update_option( 'wpcm_standings_orderby', 'pts' );
+		update_option( 'wpcm_standings_priority_order', 'DESC' );
+		update_option( 'wpcm_standings_orderby_2', 'h2h' );
+		update_option( 'wpcm_standings_priority_order_2', 'DESC' );
+		update_option( 'wpcm_standings_orderby_3', 'gd' );
+		update_option( 'wpcm_standings_priority_order_3', 'DESC' );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$clubs = $this->build_clubs_for_sort();
+		usort( $clubs, 'wpcm_sort_table_clubs' );
+
+		$this->assertEquals( $this->club_a, $clubs[0]->ID, 'Club A should be 1st (most pts)' );
+		$this->assertEquals( $this->club_b, $clubs[1]->ID, 'Club B should be 2nd' );
+		$this->assertEquals( $this->club_c, $clubs[2]->ID, 'Club C should be 3rd (0 pts)' );
+	}
+
+	public function test_h2h_falls_through_to_next_priority_when_tied() {
+		// A and B draw 0-0 in their only H2H match.
+		// A also beats C 3-0, B also beats C 1-0.
+		// A: 1W 1D 0L = 4pts, F=3 A=0 GD=+3 (H2H: 1pt)
+		// B: 1W 1D 0L = 4pts, F=1 A=0 GD=+1 (H2H: 1pt)
+		$this->create_match( $this->club_a, $this->club_b, 0, 0 );
+		$this->create_match( $this->club_a, $this->club_c, 3, 0 );
+		$this->create_match( $this->club_b, $this->club_c, 1, 0 );
+
+		update_option( 'wpcm_standings_orderby', 'pts' );
+		update_option( 'wpcm_standings_priority_order', 'DESC' );
+		update_option( 'wpcm_standings_orderby_2', 'h2h' );
+		update_option( 'wpcm_standings_priority_order_2', 'DESC' );
+		update_option( 'wpcm_standings_orderby_3', 'gd' );
+		update_option( 'wpcm_standings_priority_order_3', 'DESC' );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$clubs = $this->build_clubs_for_sort();
+		usort( $clubs, 'wpcm_sort_table_clubs' );
+
+		// A and B tied on pts (4). H2H: drew 0-0, both 1pt, GD=0. Tied on H2H.
+		// Falls through to priority 3 (GD): A has +3, B has +1. A ranks higher.
+		$this->assertEquals( $this->club_a, $clubs[0]->ID );
+		$this->assertEquals( $this->club_b, $clubs[1]->ID );
+		$this->assertEquals( $this->club_c, $clubs[2]->ID );
+	}
+
+	public function test_h2h_excludes_friendly_matches() {
+		// Friendly: A beats B 5-0 (should be ignored).
+		$friendly = $this->create_match( $this->club_a, $this->club_b, 5, 0 );
+		update_post_meta( $friendly, 'wpcm_friendly', '1' );
+
+		// Competitive: B beats A 1-0.
+		$this->create_match( $this->club_b, $this->club_a, 1, 0 );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		// Only the competitive match counts: B won, A lost.
+		$this->assertEquals( 0, $result['a_points'] );
+		$this->assertEquals( 3, $result['b_points'] );
+	}
+
+	public function test_h2h_excludes_postponed_without_walkover() {
+		// Postponed match without walkover should be excluded.
+		$postponed = $this->create_match( $this->club_a, $this->club_b, 0, 0 );
+		update_post_meta( $postponed, '_wpcm_postponed', '1' );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 0, $result['a_points'] );
+		$this->assertEquals( 0, $result['b_points'] );
+	}
+
+	public function test_h2h_includes_walkover_results() {
+		// Postponed match with home_win walkover should count.
+		$walkover = $this->create_match( $this->club_a, $this->club_b, 0, 0 );
+		update_post_meta( $walkover, '_wpcm_postponed', '1' );
+		update_post_meta( $walkover, '_wpcm_walkover', 'home_win' );
+
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 3, $result['a_points'] );
+		$this->assertEquals( 0, $result['b_points'] );
+	}
+
+	public function test_h2h_with_no_direct_matches_returns_zero() {
+		wpcm_set_h2h_context( $this->comp_id, $this->season_id );
+
+		$result = wpcm_get_h2h_points( $this->club_a, $this->club_b );
+
+		$this->assertEquals( 0, $result['a_points'] );
+		$this->assertEquals( 0, $result['b_points'] );
+		$this->assertEquals( 0, $result['a_gd'] );
+		$this->assertEquals( 0, $result['b_gd'] );
+	}
+}

--- a/tests/wpunit/IndividualSportTest.php
+++ b/tests/wpunit/IndividualSportTest.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Tests for individual (non-team) sport support.
+ *
+ * Verifies that matches can be created without an away club
+ * and that match functions handle the absence gracefully.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/96
+ */
+
+class IndividualSportTest extends WPCMTestCase {
+
+	/** @var int */
+	private $club_id;
+
+	/** @var int */
+	private $match_id;
+
+	/** @var string */
+	private $original_sport;
+
+	/** @var string|false */
+	private $original_default_club;
+
+	/** @var callable|null */
+	private $sports_filter;
+
+	/** @var array */
+	private $original_options = array();
+
+	public function _setUp() {
+		parent::_setUp();
+
+		$this->original_sport        = get_option( 'wpcm_sport' );
+		$this->original_default_club = get_option( 'wpcm_default_club' );
+
+		$options_to_snapshot = array(
+			'wpcm_match_title_format',
+			'wpcm_match_goals_delimiter',
+			'wpcm_match_clubs_separator',
+			'wpcm_hide_scores',
+		);
+		foreach ( $options_to_snapshot as $opt ) {
+			$this->original_options[ $opt ] = get_option( $opt );
+		}
+
+		$this->club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Athletics Club',
+			'post_status' => 'publish',
+		) );
+
+		update_option( 'wpcm_default_club', $this->club_id );
+
+		add_image_size( 'crest-small', 25, 25, false );
+	}
+
+	public function _tearDown() {
+		if ( $this->match_id ) {
+			wp_delete_post( $this->match_id, true );
+		}
+		wp_delete_post( $this->club_id, true );
+		update_option( 'wpcm_sport', $this->original_sport );
+
+		if ( false === $this->original_default_club ) {
+			delete_option( 'wpcm_default_club' );
+		} else {
+			update_option( 'wpcm_default_club', $this->original_default_club );
+		}
+
+		if ( $this->sports_filter ) {
+			remove_filter( 'wpcm_sports', $this->sports_filter );
+			$this->sports_filter = null;
+		}
+
+		foreach ( $this->original_options as $opt => $value ) {
+			if ( false === $value ) {
+				delete_option( $opt );
+			} else {
+				update_option( $opt, $value );
+			}
+		}
+
+		parent::_tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// Helper: set up an individual sport via filter
+	// -----------------------------------------------------------------------
+
+	private function register_individual_sport() {
+		update_option( 'wpcm_sport', 'athletics' );
+
+		$this->sports_filter = function ( $sports ) {
+			$sports['athletics'] = array(
+				'name'              => 'Athletics',
+				'has_teams'         => false,
+				'terms'             => array(
+					'wpcm_position' => array(
+						array( 'name' => '', 'slug' => '' ),
+					),
+				),
+				'stats_labels'      => array(
+					'mvp' => array(
+						'name'  => 'Player of Match',
+						'label' => 'POM',
+					),
+				),
+				'standings_columns' => array(
+					'p'   => array( 'name' => 'Played', 'label' => 'P' ),
+					'w'   => array( 'name' => 'Won', 'label' => 'W' ),
+					'l'   => array( 'name' => 'Lost', 'label' => 'L' ),
+					'pts' => array( 'name' => 'Points', 'label' => 'Pts' ),
+				),
+			);
+			return $sports;
+		};
+		add_filter( 'wpcm_sports', $this->sports_filter );
+	}
+
+	private function create_individual_match( $played = false ) {
+		$this->match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Athletics Event',
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $this->match_id, 'wpcm_home_club', $this->club_id );
+		// No away club set — this is the key difference for individual sports.
+
+		if ( $played ) {
+			update_post_meta( $this->match_id, 'wpcm_played', '1' );
+			update_post_meta( $this->match_id, 'wpcm_home_goals', '1' );
+		}
+
+		return $this->match_id;
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_is_team_sport()
+	// -----------------------------------------------------------------------
+
+	public function test_team_sport_returns_true_for_soccer() {
+		update_option( 'wpcm_sport', 'soccer' );
+		$this->assertTrue( wpcm_is_team_sport() );
+	}
+
+	public function test_team_sport_returns_false_for_individual_sport() {
+		$this->register_individual_sport();
+		$this->assertFalse( wpcm_is_team_sport() );
+	}
+
+	public function test_team_sport_defaults_to_true_for_unknown_sport() {
+		update_option( 'wpcm_sport', 'unknown_sport_xyz' );
+		$this->assertTrue( wpcm_is_team_sport() );
+	}
+
+	// -----------------------------------------------------------------------
+	// Match title — should show only the club name, not "Club vs "
+	// -----------------------------------------------------------------------
+
+	public function test_match_title_shows_only_club_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		$title = match_title( 'Athletics Event', $match_id );
+
+		$this->assertEquals( 'Athletics Club', $title );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_clubs() — side2 should be empty
+	// -----------------------------------------------------------------------
+
+	public function test_match_clubs_returns_empty_side2_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		update_option( 'wpcm_match_title_format', '%home% vs %away%' );
+		$sides = wpcm_get_match_clubs( $match_id );
+
+		$this->assertNotEmpty( $sides[0] );
+		$this->assertEmpty( $sides[1] );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_opponents() — should return empty for individual sport
+	// -----------------------------------------------------------------------
+
+	public function test_match_opponents_returns_empty_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		$opponent = wpcm_get_match_opponents( $match_id );
+
+		$this->assertEmpty( $opponent );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_result() — should return only home score
+	// -----------------------------------------------------------------------
+
+	public function test_match_result_returns_home_score_only_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match( true );
+
+		update_option( 'wpcm_match_title_format', '%home% vs %away%' );
+		update_option( 'wpcm_match_goals_delimiter', '-' );
+
+		$result = wpcm_get_match_result( $match_id );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( '1', $result[1] );
+		$this->assertEmpty( $result[2] );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_outcome() — no away club, so just check it handles gracefully
+	// -----------------------------------------------------------------------
+
+	public function test_match_outcome_returns_win_for_played_individual_match() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match( true );
+
+		$outcome = wpcm_get_match_outcome( $match_id );
+
+		$this->assertEquals( 'win', $outcome );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_badges() — should return only one badge
+	// -----------------------------------------------------------------------
+
+	public function test_match_badges_returns_empty_badge2_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		update_option( 'wpcm_match_title_format', '%home% vs %away%' );
+		$badges = wpcm_get_match_badges( $match_id, 'crest-small' );
+
+		$this->assertNotEmpty( $badges[0] );
+		$this->assertEmpty( $badges[1] );
+	}
+
+	// -----------------------------------------------------------------------
+	// wpcm_get_match_venue() — should still work without away club
+	// -----------------------------------------------------------------------
+
+	public function test_match_venue_returns_home_status_for_individual_sport() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		$venue = wpcm_get_match_venue( $match_id );
+
+		$this->assertIsArray( $venue );
+	}
+
+	// -----------------------------------------------------------------------
+	// Match creation — can create match without away club
+	// -----------------------------------------------------------------------
+
+	public function test_can_create_match_without_away_club() {
+		$this->register_individual_sport();
+		$match_id = $this->create_individual_match();
+
+		$this->assertGreaterThan( 0, $match_id );
+		$this->assertEquals( 'wpcm_match', get_post_type( $match_id ) );
+		$this->assertEquals(
+			$this->club_id,
+			(int) get_post_meta( $match_id, 'wpcm_home_club', true )
+		);
+		$this->assertEmpty( get_post_meta( $match_id, 'wpcm_away_club', true ) );
+	}
+}

--- a/tests/wpunit/LeagueTablePostTypeTest.php
+++ b/tests/wpunit/LeagueTablePostTypeTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Tests for league table (wpcm_table) post type public visibility.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/82
+ */
+
+class LeagueTablePostTypeTest extends WPCMTestCase {
+
+	public function test_league_table_post_type_is_public() {
+		$obj = get_post_type_object( 'wpcm_table' );
+		$this->assertNotNull( $obj );
+		$this->assertTrue( $obj->public, 'wpcm_table should be public' );
+	}
+
+	public function test_league_table_post_type_is_publicly_queryable() {
+		$obj = get_post_type_object( 'wpcm_table' );
+		$this->assertNotNull( $obj );
+		$this->assertTrue( $obj->publicly_queryable, 'wpcm_table should be publicly queryable' );
+	}
+
+	public function test_league_table_post_type_has_query_var() {
+		$obj = get_post_type_object( 'wpcm_table' );
+		$this->assertNotNull( $obj );
+		$this->assertNotFalse( $obj->query_var, 'wpcm_table should have a query var' );
+	}
+
+	public function test_league_table_post_type_has_rewrite() {
+		$obj = get_post_type_object( 'wpcm_table' );
+		$this->assertNotNull( $obj );
+		$this->assertNotFalse( $obj->rewrite, 'wpcm_table should have rewrite rules' );
+	}
+
+	public function test_league_table_default_rewrite_slug() {
+		// Assert the already-registered post type has the expected default slug.
+		// Cannot unregister and call register_post_types() because its guard
+		// bails out when wpcm_player is already registered.
+		$obj = get_post_type_object( 'wpcm_table' );
+		$this->assertNotNull( $obj );
+		$this->assertIsArray( $obj->rewrite );
+		$this->assertEquals( 'table', $obj->rewrite['slug'] );
+	}
+
+	public function test_league_table_custom_rewrite_slug() {
+		update_option( 'wpclubmanager_table_slug', 'league-table' );
+
+		// Unregister and re-register directly since register_post_types()
+		// guards against re-registration when wpcm_player already exists.
+		unregister_post_type( 'wpcm_table' );
+
+		$slug = get_option( 'wpclubmanager_table_slug' );
+		register_post_type( 'wpcm_table', array(
+			'public'             => true,
+			'publicly_queryable' => true,
+			'query_var'          => true,
+			'rewrite'            => array( 'slug' => untrailingslashit( $slug ) ),
+			'show_in_rest'       => true,
+			'capability_type'    => 'wpcm_table',
+			'map_meta_cap'       => true,
+		) );
+
+		$obj = get_post_type_object( 'wpcm_table' );
+		$this->assertNotNull( $obj );
+		$this->assertIsArray( $obj->rewrite );
+		$this->assertEquals( 'league-table', $obj->rewrite['slug'] );
+
+		// Restore default registration for subsequent tests.
+		delete_option( 'wpclubmanager_table_slug' );
+		unregister_post_type( 'wpcm_table' );
+		register_post_type( 'wpcm_table', array(
+			'public'             => true,
+			'publicly_queryable' => true,
+			'query_var'          => true,
+			'rewrite'            => array( 'slug' => 'table' ),
+			'show_in_rest'       => true,
+			'capability_type'    => 'wpcm_table',
+			'map_meta_cap'       => true,
+		) );
+	}
+
+	public function test_league_table_single_page_resolves() {
+		$post_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_table',
+			'post_title'  => 'Premier League',
+			'post_status' => 'publish',
+		) );
+
+		$this->assertGreaterThan( 0, $post_id );
+
+		$permalink = get_permalink( $post_id );
+		$this->assertNotEmpty( $permalink );
+		$this->assertStringContainsString( 'table', $permalink );
+
+		wp_delete_post( $post_id, true );
+	}
+}

--- a/tests/wpunit/MatchCalendarTest.php
+++ b/tests/wpunit/MatchCalendarTest.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Tests for the match_calendar shortcode and iCal feed.
+ *
+ * Covers shortcode registration, calendar grid output with matches,
+ * month navigation attributes, taxonomy filtering, and iCal feed
+ * generation with valid VCALENDAR/VEVENT structure.
+ */
+
+class MatchCalendarTest extends WPCMTestCase {
+
+	/** @var int */
+	private $home_club_id;
+
+	/** @var int */
+	private $away_club_id;
+
+	/** @var int[] */
+	private $match_ids = array();
+
+	/** @var int */
+	private $comp_term_id;
+
+	/** @var int */
+	private $season_term_id;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		$this->home_club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Home FC',
+			'post_status' => 'publish',
+		) );
+
+		$this->away_club_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Away United',
+			'post_status' => 'publish',
+		) );
+
+		update_option( 'wpcm_default_club', $this->home_club_id );
+
+		$comp = wp_insert_term( 'Test League', 'wpcm_comp' );
+		$this->comp_term_id = is_wp_error( $comp ) ? $comp->get_error_data() : $comp['term_id'];
+
+		$season = wp_insert_term( '2026', 'wpcm_season' );
+		$this->season_term_id = is_wp_error( $season ) ? $season->get_error_data() : $season['term_id'];
+	}
+
+	public function _tearDown() {
+		foreach ( $this->match_ids as $id ) {
+			wp_delete_post( $id, true );
+		}
+		wp_delete_post( $this->home_club_id, true );
+		wp_delete_post( $this->away_club_id, true );
+
+		parent::_tearDown();
+	}
+
+	/**
+	 * Helper to create a match on a specific date.
+	 *
+	 * @param string $date Y-m-d H:i:s format.
+	 * @param bool   $played Whether the match has been played.
+	 * @return int Post ID.
+	 */
+	private function create_match( $date, $played = false ) {
+		$status = ( strtotime( $date ) > time() && ! $played ) ? 'future' : 'publish';
+
+		$match_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_match',
+			'post_title'  => 'Home FC vs Away United',
+			'post_status' => $status,
+			'post_date'   => $date,
+		) );
+
+		update_post_meta( $match_id, 'wpcm_home_club', $this->home_club_id );
+		update_post_meta( $match_id, 'wpcm_away_club', $this->away_club_id );
+		update_post_meta( $match_id, '_wpcm_match_datetime', $date );
+
+		if ( $played ) {
+			update_post_meta( $match_id, 'wpcm_played', '1' );
+			update_post_meta( $match_id, 'wpcm_home_goals', '2' );
+			update_post_meta( $match_id, 'wpcm_away_goals', '1' );
+		}
+
+		wp_set_object_terms( $match_id, $this->comp_term_id, 'wpcm_comp' );
+		wp_set_object_terms( $match_id, $this->season_term_id, 'wpcm_season' );
+
+		$this->match_ids[] = $match_id;
+
+		return $match_id;
+	}
+
+	// -------------------------------------------------------------------
+	// Shortcode registration
+	// -------------------------------------------------------------------
+
+	public function test_match_calendar_shortcode_is_registered() {
+		$this->assertTrue( shortcode_exists( 'match_calendar' ), 'Shortcode [match_calendar] should be registered' );
+	}
+
+	// -------------------------------------------------------------------
+	// Calendar output structure
+	// -------------------------------------------------------------------
+
+	public function test_calendar_outputs_wrapper_div() {
+		$output = do_shortcode( '[match_calendar]' );
+		$this->assertStringContainsString( 'wpcm-shortcode-wrapper', $output );
+	}
+
+	public function test_calendar_outputs_calendar_table() {
+		$output = do_shortcode( '[match_calendar]' );
+		$this->assertStringContainsString( 'wpcm-calendar', $output );
+		$this->assertStringContainsString( '<table', $output );
+	}
+
+	public function test_calendar_shows_month_and_year_heading() {
+		$output = do_shortcode( '[match_calendar month="6" year="2026"]' );
+		$this->assertStringContainsString( 'wpcm-calendar-title', $output );
+		$this->assertStringContainsString( '2026', $output );
+	}
+
+	public function test_calendar_shows_day_of_week_headers() {
+		$output = do_shortcode( '[match_calendar month="6" year="2026"]' );
+		// Assert 7 column headers exist regardless of locale.
+		preg_match_all( '/<th[\s>]/', $output, $th_matches );
+		$this->assertCount( 7, $th_matches[0], 'Calendar should have 7 day-of-week headers' );
+	}
+
+	// -------------------------------------------------------------------
+	// Matches in the calendar
+	// -------------------------------------------------------------------
+
+	public function test_calendar_displays_match_on_correct_day() {
+		$this->create_match( '2026-01-15 15:00:00', true );
+
+		$output = do_shortcode( '[match_calendar month="1" year="2026"]' );
+		$this->assertStringContainsString( 'wpcm-calendar-match', $output );
+	}
+
+	public function test_calendar_shows_future_fixtures() {
+		$this->create_match( '2028-06-20 19:30:00', false );
+
+		$output = do_shortcode( '[match_calendar month="6" year="2028"]' );
+		$this->assertStringContainsString( 'wpcm-calendar-match', $output );
+	}
+
+	public function test_calendar_filters_by_competition() {
+		$this->create_match( '2026-03-10 15:00:00', true );
+
+		$output = do_shortcode( '[match_calendar month="3" year="2026" comp="' . $this->comp_term_id . '"]' );
+		$this->assertStringContainsString( 'wpcm-calendar-match', $output );
+
+		// Non-existent comp should show no matches.
+		$output_empty = do_shortcode( '[match_calendar month="3" year="2026" comp="99999"]' );
+		$this->assertStringNotContainsString( 'wpcm-calendar-match', $output_empty );
+	}
+
+	public function test_calendar_filters_by_season() {
+		$this->create_match( '2026-04-05 14:00:00', true );
+
+		$output = do_shortcode( '[match_calendar month="4" year="2026" season="' . $this->season_term_id . '"]' );
+		$this->assertStringContainsString( 'wpcm-calendar-match', $output );
+	}
+
+	// -------------------------------------------------------------------
+	// iCal feed
+	// -------------------------------------------------------------------
+
+	public function test_ical_feed_class_exists() {
+		$this->assertTrue( class_exists( 'WPCM_ICal_Feed' ), 'WPCM_ICal_Feed class should exist' );
+	}
+
+	public function test_ical_generate_returns_valid_vcalendar() {
+		$this->create_match( '2026-02-14 15:00:00', true );
+
+		$feed   = new WPCM_ICal_Feed();
+		$output = $feed->generate();
+
+		$this->assertStringContainsString( 'BEGIN:VCALENDAR', $output );
+		$this->assertStringContainsString( 'END:VCALENDAR', $output );
+		$this->assertStringContainsString( 'VERSION:2.0', $output );
+		$this->assertStringContainsString( 'PRODID:', $output );
+	}
+
+	public function test_ical_contains_vevent_for_match() {
+		$this->create_match( '2026-02-14 15:00:00', true );
+
+		$feed   = new WPCM_ICal_Feed();
+		$output = $feed->generate();
+
+		$this->assertStringContainsString( 'BEGIN:VEVENT', $output );
+		$this->assertStringContainsString( 'END:VEVENT', $output );
+		$this->assertStringContainsString( 'DTSTART:', $output );
+		$this->assertStringContainsString( 'SUMMARY:', $output );
+	}
+
+	public function test_ical_vevent_contains_match_title() {
+		$this->create_match( '2026-02-14 15:00:00', true );
+
+		$feed   = new WPCM_ICal_Feed();
+		$output = $feed->generate();
+
+		$this->assertStringContainsString( 'Home FC', $output );
+	}
+
+	public function test_ical_filters_by_competition() {
+		$this->create_match( '2026-02-14 15:00:00', true );
+
+		$feed   = new WPCM_ICal_Feed();
+		$output = $feed->generate( array( 'comp' => $this->comp_term_id ) );
+		$this->assertStringContainsString( 'BEGIN:VEVENT', $output );
+
+		$output_empty = $feed->generate( array( 'comp' => 99999 ) );
+		$this->assertStringNotContainsString( 'BEGIN:VEVENT', $output_empty );
+	}
+
+	public function test_ical_filters_by_season() {
+		$this->create_match( '2026-02-14 15:00:00', true );
+
+		$feed   = new WPCM_ICal_Feed();
+		$output = $feed->generate( array( 'season' => $this->season_term_id ) );
+		$this->assertStringContainsString( 'BEGIN:VEVENT', $output );
+	}
+
+	public function test_ical_dtstart_format_is_correct() {
+		$this->create_match( '2026-02-14 15:00:00', true );
+
+		$feed   = new WPCM_ICal_Feed();
+		$output = $feed->generate();
+
+		// iCal datetime format: YYYYMMDDTHHMMSSZ (UTC).
+		$this->assertMatchesRegularExpression( '/DTSTART:\d{8}T\d{6}Z/', $output );
+	}
+
+	public function test_ical_has_uid_per_event() {
+		$this->create_match( '2026-02-14 15:00:00', true );
+
+		$feed   = new WPCM_ICal_Feed();
+		$output = $feed->generate();
+
+		$this->assertStringContainsString( 'UID:', $output );
+	}
+
+	public function test_ical_empty_when_no_matches() {
+		$feed   = new WPCM_ICal_Feed();
+		$output = $feed->generate();
+
+		$this->assertStringContainsString( 'BEGIN:VCALENDAR', $output );
+		$this->assertStringNotContainsString( 'BEGIN:VEVENT', $output );
+	}
+
+	// -------------------------------------------------------------------
+	// iCal feed URL
+	// -------------------------------------------------------------------
+
+	public function test_ical_feed_url_contains_wpcm_ical() {
+		$feed = new WPCM_ICal_Feed();
+		$url  = $feed->get_feed_url();
+
+		$this->assertStringContainsString( 'wpcm_ical', $url );
+	}
+}

--- a/tests/wpunit/MatchImportTaxonomyTest.php
+++ b/tests/wpunit/MatchImportTaxonomyTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Tests for match importer taxonomy term lookup.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/95
+ */
+class MatchImportTaxonomyTest extends WPCMTestCase {
+
+	/**
+	 * @var WPCM_Match_Importer|null
+	 */
+	private $importer;
+
+	/**
+	 * @var int[]
+	 */
+	private $created_posts = array();
+
+	/**
+	 * @var array[] Array of ( taxonomy, term_id ) pairs.
+	 */
+	private $created_terms = array();
+
+	public function _setUp() {
+		parent::_setUp();
+
+		if ( ! class_exists( 'WP_Importer' ) ) {
+			$wp_importer_file = ABSPATH . 'wp-admin/includes/class-wp-importer.php';
+			if ( file_exists( $wp_importer_file ) ) {
+				require_once $wp_importer_file;
+			}
+		}
+
+		$importer_file = WPCM()->plugin_path() . '/includes/admin/importers/class-wpcm-importer.php';
+		if ( file_exists( $importer_file ) ) {
+			require_once $importer_file;
+		}
+
+		$match_importer_file = WPCM()->plugin_path() . '/includes/admin/importers/class-wpcm-match-importer.php';
+		if ( file_exists( $match_importer_file ) ) {
+			require_once $match_importer_file;
+		}
+
+		if ( class_exists( 'WPCM_Match_Importer' ) ) {
+			$this->importer = new WPCM_Match_Importer();
+		}
+
+		// Create home and away clubs for the import.
+		$this->created_posts[] = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Arsenal',
+			'post_status' => 'publish',
+		) );
+		$this->created_posts[] = wp_insert_post( array(
+			'post_type'   => 'wpcm_club',
+			'post_title'  => 'Chelsea',
+			'post_status' => 'publish',
+		) );
+	}
+
+	public function _tearDown() {
+		foreach ( $this->created_posts as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		foreach ( $this->created_terms as $entry ) {
+			wp_delete_term( $entry[1], $entry[0] );
+		}
+		parent::_tearDown();
+	}
+
+	/**
+	 * Test that the importer finds existing competition terms by name.
+	 */
+	public function test_import_finds_existing_competition() {
+		if ( ! $this->importer ) {
+			$this->markTestSkipped( 'WP_Importer class not available.' );
+		}
+
+		$term = wp_insert_term( 'Premier League', 'wpcm_comp' );
+		$this->assertNotWPError( $term );
+		$term_id               = $term['term_id'];
+		$this->created_terms[] = array( 'wpcm_comp', $term_id );
+
+		$columns = array_keys( $this->importer->columns );
+		$data    = array(
+			'2024/01/15', '15:00:00', 'Arsenal', 'Chelsea', '2-1',
+			'Premier League', '2023-24', 'First Team', 'Emirates Stadium',
+			'60000', 'Mike Dean', '',
+		);
+
+		ob_start();
+		$this->importer->import( $data, $columns );
+		ob_end_clean();
+
+		// Find the imported match.
+		$matches = get_posts( array(
+			'post_type'   => 'wpcm_match',
+			'numberposts' => 1,
+			'orderby'     => 'ID',
+			'order'       => 'DESC',
+		) );
+		$this->assertNotEmpty( $matches, 'Match should have been imported.' );
+		$match_id              = $matches[0]->ID;
+		$this->created_posts[] = $match_id;
+
+		// The match should be assigned to the existing competition term.
+		$match_comps = wp_get_object_terms( $match_id, 'wpcm_comp' );
+		$this->assertCount( 1, $match_comps, 'Match should have exactly one competition term.' );
+		$this->assertEquals( $term_id, $match_comps[0]->term_id, 'Match should use the existing competition term, not create a new one.' );
+		$this->assertEquals( 'Premier League', $match_comps[0]->name, 'Competition term should retain its original name.' );
+
+		// Track season, team, and venue terms created by the import for cleanup.
+		foreach ( array( 'wpcm_season', 'wpcm_team', 'wpcm_venue' ) as $taxonomy ) {
+			$terms = wp_get_object_terms( $match_id, $taxonomy );
+			foreach ( $terms as $t ) {
+				$this->created_terms[] = array( $taxonomy, $t->term_id );
+			}
+		}
+	}
+
+	/**
+	 * Test that new terms created during import have proper names, not slugs.
+	 */
+	public function test_import_creates_terms_with_proper_names() {
+		if ( ! $this->importer ) {
+			$this->markTestSkipped( 'WP_Importer class not available.' );
+		}
+
+		$columns = array_keys( $this->importer->columns );
+		$data    = array(
+			'2024/01/15', '15:00:00', 'Arsenal', 'Chelsea', '2-1',
+			'FA Cup', '2023-24', 'First Team', 'Wembley Stadium',
+			'90000', 'Mike Dean', '',
+		);
+
+		ob_start();
+		$this->importer->import( $data, $columns );
+		ob_end_clean();
+
+		$matches = get_posts( array(
+			'post_type'   => 'wpcm_match',
+			'numberposts' => 1,
+			'orderby'     => 'ID',
+			'order'       => 'DESC',
+		) );
+		$this->assertNotEmpty( $matches );
+		$match_id              = $matches[0]->ID;
+		$this->created_posts[] = $match_id;
+
+		// Check that terms were created with proper human-readable names.
+		$comps = wp_get_object_terms( $match_id, 'wpcm_comp' );
+		$this->assertCount( 1, $comps );
+		$this->assertEquals( 'FA Cup', $comps[0]->name, 'Competition should be created with proper name, not slug.' );
+		$this->created_terms[] = array( 'wpcm_comp', $comps[0]->term_id );
+
+		$seasons = wp_get_object_terms( $match_id, 'wpcm_season' );
+		$this->assertCount( 1, $seasons );
+		$this->assertEquals( '2023-24', $seasons[0]->name, 'Season should be created with proper name, not slug.' );
+		$this->created_terms[] = array( 'wpcm_season', $seasons[0]->term_id );
+
+		$teams = wp_get_object_terms( $match_id, 'wpcm_team' );
+		$this->assertCount( 1, $teams );
+		$this->assertEquals( 'First Team', $teams[0]->name, 'Team should be created with proper name, not slug.' );
+		$this->created_terms[] = array( 'wpcm_team', $teams[0]->term_id );
+
+		$venues = wp_get_object_terms( $match_id, 'wpcm_venue' );
+		$this->assertCount( 1, $venues );
+		$this->assertEquals( 'Wembley Stadium', $venues[0]->name, 'Venue should be created with proper name, not slug.' );
+		$this->created_terms[] = array( 'wpcm_venue', $venues[0]->term_id );
+	}
+}

--- a/tests/wpunit/PlayerGalleryLinkTest.php
+++ b/tests/wpunit/PlayerGalleryLinkTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Tests for the player_gallery shortcode linkimage attribute.
+ *
+ * Verifies that the linkimage attribute controls whether player
+ * photos and names are wrapped in links to the player profile.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/97
+ */
+
+class PlayerGalleryLinkTest extends WPCMTestCase {
+
+	/** @var int */
+	private $roster_id;
+
+	/** @var int */
+	private $player_id;
+
+	/** @var int */
+	private $season_id;
+
+	/** @var int */
+	private $team_id;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		// Disable shortcode output caching for tests.
+		update_option( 'wpcm_disable_cache', 'yes' );
+
+		// Create a season and team term.
+		$season = wp_insert_term( 'Test Season', 'wpcm_season' );
+		if ( is_wp_error( $season ) ) {
+			$this->season_id = $season->get_error_data();
+		} else {
+			$this->season_id = $season['term_id'];
+		}
+		$team = wp_insert_term( 'Test Team', 'wpcm_team' );
+		if ( is_wp_error( $team ) ) {
+			$this->team_id = $team->get_error_data();
+		} else {
+			$this->team_id = $team['term_id'];
+		}
+
+		// Create a player.
+		$this->player_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_player',
+			'post_title'  => 'Gallery Player',
+			'post_status' => 'publish',
+		) );
+		update_post_meta( $this->player_id, 'wpcm_number', '10' );
+
+		// Create a roster and assign the player.
+		$this->roster_id = wp_insert_post( array(
+			'post_type'   => 'wpcm_roster',
+			'post_title'  => 'Test Roster',
+			'post_status' => 'publish',
+		) );
+		update_post_meta( $this->roster_id, '_wpcm_roster_players', array( $this->player_id ) );
+		wp_set_object_terms( $this->roster_id, $this->season_id, 'wpcm_season' );
+		wp_set_object_terms( $this->roster_id, $this->team_id, 'wpcm_team' );
+	}
+
+	public function _tearDown() {
+		wp_delete_post( $this->roster_id, true );
+		wp_delete_post( $this->player_id, true );
+		wp_delete_term( $this->season_id, 'wpcm_season' );
+		wp_delete_term( $this->team_id, 'wpcm_team' );
+		parent::_tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// Default behaviour — images are linked
+	// -----------------------------------------------------------------------
+
+	public function test_player_gallery_image_is_linked_by_default() {
+		$output = do_shortcode( '[player_gallery id="' . $this->roster_id . '"]' );
+		$url    = preg_quote( esc_url( get_permalink( $this->player_id ) ), '/' );
+
+		$this->assertMatchesRegularExpression( '/<a\s[^>]*href="' . $url . '"/', $output );
+		$this->assertMatchesRegularExpression( '/<h4>\s*<a\s[^>]*href="' . $url . '"/', $output );
+	}
+
+	// -----------------------------------------------------------------------
+	// linkimage="no" — images are NOT linked
+	// -----------------------------------------------------------------------
+
+	public function test_player_gallery_image_not_linked_when_linkimage_no() {
+		$output = do_shortcode( '[player_gallery id="' . $this->roster_id . '" linkimage="no"]' );
+		$url    = preg_quote( esc_url( get_permalink( $this->player_id ) ), '/' );
+
+		$this->assertDoesNotMatchRegularExpression( '/<a\s[^>]*href="' . $url . '"/', $output );
+		$this->assertDoesNotMatchRegularExpression( '/<h4>\s*<a\s[^>]*href="' . $url . '"/', $output );
+		// The image should still be rendered, just without the link.
+		$this->assertStringContainsString( 'wpcm-players-gallery', $output );
+	}
+
+	// -----------------------------------------------------------------------
+	// linkimage="yes" — explicit yes still links
+	// -----------------------------------------------------------------------
+
+	public function test_player_gallery_image_linked_when_linkimage_yes() {
+		$output = do_shortcode( '[player_gallery id="' . $this->roster_id . '" linkimage="yes"]' );
+		$url    = preg_quote( esc_url( get_permalink( $this->player_id ) ), '/' );
+
+		$this->assertMatchesRegularExpression( '/<a\s[^>]*href="' . $url . '"/', $output );
+		$this->assertMatchesRegularExpression( '/<h4>\s*<a\s[^>]*href="' . $url . '"/', $output );
+	}
+}

--- a/tests/wpunit/PlayerStatsTest.php
+++ b/tests/wpunit/PlayerStatsTest.php
@@ -118,6 +118,101 @@ class PlayerStatsTest extends WPCMTestCase {
 	}
 
 	// -----------------------------------------------------------------------
+	// get_wpcm_player_stats() — combined manual stats
+	// -----------------------------------------------------------------------
+
+	public function test_get_wpcm_player_stats_combined_manual_stats_does_not_use_per_team_values() {
+		$team = wp_insert_term( 'Stats Team', 'wpcm_team' );
+		if ( is_wp_error( $team ) ) {
+			$team_id = $team->get_error_data();
+		} else {
+			$team_id = $team['term_id'];
+		}
+
+		$season = wp_insert_term( 'Stats Season', 'wpcm_season' );
+		if ( is_wp_error( $season ) ) {
+			$season_id = $season->get_error_data();
+		} else {
+			$season_id = $season['term_id'];
+		}
+
+		wp_set_object_terms( $this->player_id, $team_id, 'wpcm_team' );
+		wp_set_object_terms( $this->player_id, $season_id, 'wpcm_season' );
+
+		// Only store per-team stats — no (0,0) combined entry.
+		// Before the fix, the combined entry would pick up per-team values
+		// because stale loop variables were passed to get_wpcm_player_manual_stats().
+		$stats = array(
+			$team_id => array(
+				$season_id => array(
+					'appearances' => 5,
+					'goals'       => 2,
+				),
+			),
+		);
+
+		update_post_meta( $this->player_id, 'wpcm_stats', serialize( $stats ) );
+
+		$result = get_wpcm_player_stats( $this->player_id );
+
+		// The combined entry should use the (0,0) manual stats (empty defaults),
+		// NOT the per-team values that would leak via stale loop variables.
+		$this->assertArrayHasKey( 'manual', $result[0][0] );
+		$this->assertEquals( 0, $result[0][0]['manual']['appearances'] );
+		$this->assertEquals( 0, $result[0][0]['manual']['goals'] );
+
+		wp_delete_term( $team_id, 'wpcm_team' );
+		wp_delete_term( $season_id, 'wpcm_season' );
+	}
+
+	public function test_get_wpcm_player_stats_combined_manual_stats_uses_combined_entry() {
+		$team = wp_insert_term( 'Stats Team 2', 'wpcm_team' );
+		if ( is_wp_error( $team ) ) {
+			$team_id = $team->get_error_data();
+		} else {
+			$team_id = $team['term_id'];
+		}
+
+		$season = wp_insert_term( 'Stats Season 2', 'wpcm_season' );
+		if ( is_wp_error( $season ) ) {
+			$season_id = $season->get_error_data();
+		} else {
+			$season_id = $season['term_id'];
+		}
+
+		wp_set_object_terms( $this->player_id, $team_id, 'wpcm_team' );
+		wp_set_object_terms( $this->player_id, $season_id, 'wpcm_season' );
+
+		// Store manual stats under the combined key (0,0) and a per-team key.
+		$stats = array(
+			0        => array(
+				0 => array(
+					'appearances' => 12,
+					'goals'       => 8,
+				),
+			),
+			$team_id => array(
+				$season_id => array(
+					'appearances' => 5,
+					'goals'       => 2,
+				),
+			),
+		);
+
+		update_post_meta( $this->player_id, 'wpcm_stats', serialize( $stats ) );
+
+		$result = get_wpcm_player_stats( $this->player_id );
+
+		// When (0,0) exists, it should be used for the combined entry.
+		$this->assertArrayHasKey( 'manual', $result[0][0] );
+		$this->assertEquals( 12, $result[0][0]['manual']['appearances'] );
+		$this->assertEquals( 8, $result[0][0]['manual']['goals'] );
+
+		wp_delete_term( $team_id, 'wpcm_team' );
+		wp_delete_term( $season_id, 'wpcm_season' );
+	}
+
+	// -----------------------------------------------------------------------
 	// get_wpcm_player_stats_empty_row()
 	// -----------------------------------------------------------------------
 

--- a/tests/wpunit/PostTypesTest.php
+++ b/tests/wpunit/PostTypesTest.php
@@ -45,18 +45,6 @@ class PostTypesTest extends WPCMTestCase {
 			array( 'wpcm_staff' ),
 			array( 'wpcm_match' ),
 			array( 'wpcm_sponsor' ),
-		);
-	}
-
-	/** @dataProvider non_public_post_types */
-	public function test_post_type_is_not_public( $cpt ) {
-		$obj = get_post_type_object( $cpt );
-		$this->assertNotNull( $obj );
-		$this->assertFalse( $obj->public, "{$cpt} should not be public" );
-	}
-
-	public function non_public_post_types() {
-		return array(
 			array( 'wpcm_table' ),
 		);
 	}

--- a/tests/wpunit/SettingsExportImportTest.php
+++ b/tests/wpunit/SettingsExportImportTest.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Tests for settings export/import functionality.
+ *
+ * Verifies that WPCM settings can be exported to JSON and
+ * imported back, preserving all option values.
+ *
+ * @see https://github.com/WPClubManager/wp-club-manager/issues/99
+ */
+
+class SettingsExportImportTest extends WPCMTestCase {
+
+	/**
+	 * Options to clean up after each test.
+	 *
+	 * @var array
+	 */
+	private $test_options = array();
+
+	public function _setUp() {
+		parent::_setUp();
+		$this->test_options = array();
+
+		if ( ! class_exists( 'WPCM_Settings_Page' ) ) {
+			include_once WPCM_PATH . 'includes/admin/settings/class-wpcm-settings-page.php';
+		}
+
+		if ( ! class_exists( 'WPCM_Admin_Settings' ) ) {
+			include_once WPCM_PATH . 'includes/admin/class-wpcm-admin-settings.php';
+		}
+
+		if ( ! class_exists( 'WPCM_Settings_Tools' ) ) {
+			include_once WPCM_PATH . 'includes/admin/settings/class-wpcm-settings-tools.php';
+		}
+	}
+
+	public function _tearDown() {
+		foreach ( $this->test_options as $option ) {
+			delete_option( $option );
+		}
+		parent::_tearDown();
+	}
+
+	/**
+	 * Helper to set a test option and track it for cleanup.
+	 */
+	private function set_option( $name, $value ) {
+		update_option( $name, $value );
+		$this->test_options[] = $name;
+	}
+
+	// -------------------------------------------------------------------
+	// Export
+	// -------------------------------------------------------------------
+
+	public function test_export_returns_array_of_wpcm_options() {
+		$this->set_option( 'wpcm_sport', 'soccer' );
+		$this->set_option( 'wpcm_mode', 'club' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertIsArray( $exported );
+		$this->assertArrayHasKey( 'wpcm_sport', $exported );
+		$this->assertArrayHasKey( 'wpcm_mode', $exported );
+		$this->assertEquals( 'soccer', $exported['wpcm_sport'] );
+		$this->assertEquals( 'club', $exported['wpcm_mode'] );
+	}
+
+	public function test_export_includes_wpclubmanager_prefixed_options() {
+		$this->set_option( 'wpclubmanager_player_slug', 'players' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertArrayHasKey( 'wpclubmanager_player_slug', $exported );
+		$this->assertEquals( 'players', $exported['wpclubmanager_player_slug'] );
+	}
+
+	public function test_export_excludes_internal_options() {
+		$this->set_option( 'wpclubmanager_version', '2.3.3' );
+		$this->set_option( 'wpclubmanager_installed', '1' );
+		$this->set_option( 'wpcm_version_upgraded_from', '2.3.0' );
+		$this->set_option( 'wpclubmanager_admin_footer_text_rated', '1' );
+		$this->set_option( 'wpcm_transient_keys', array( 'key1' ) );
+		$this->set_option( 'wpclubmanager_admin_notices', array( 'notice1' ) );
+		$this->set_option( 'wpclubmanager_meta_box_errors', array( 'error1' ) );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertArrayNotHasKey( 'wpclubmanager_version', $exported );
+		$this->assertArrayNotHasKey( 'wpclubmanager_installed', $exported );
+		$this->assertArrayNotHasKey( 'wpcm_version_upgraded_from', $exported );
+		$this->assertArrayNotHasKey( 'wpclubmanager_admin_footer_text_rated', $exported );
+		$this->assertArrayNotHasKey( 'wpcm_transient_keys', $exported );
+		$this->assertArrayNotHasKey( 'wpclubmanager_admin_notices', $exported );
+		$this->assertArrayNotHasKey( 'wpclubmanager_meta_box_errors', $exported );
+	}
+
+	public function test_export_excludes_non_wpcm_options() {
+		$this->set_option( 'blogname', 'Test Site' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertArrayNotHasKey( 'blogname', $exported );
+	}
+
+	public function test_export_handles_serialized_values() {
+		$array_value = array( 'p', 'w', 'd', 'l', 'f', 'a', 'gd', 'pts' );
+		$this->set_option( 'wpcm_standings_columns_display', $array_value );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		$this->assertArrayHasKey( 'wpcm_standings_columns_display', $exported );
+		$this->assertEquals( $array_value, $exported['wpcm_standings_columns_display'] );
+	}
+
+	// -------------------------------------------------------------------
+	// Import
+	// -------------------------------------------------------------------
+
+	public function test_import_restores_options_from_valid_data() {
+		$import_data = array(
+			'wpcm_sport'           => 'rugby',
+			'wpcm_mode'            => 'league',
+			'wpcm_default_country' => 'GB',
+		);
+
+		$result = WPCM_Settings_Tools::import_settings( $import_data );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( 'rugby', get_option( 'wpcm_sport' ) );
+		$this->assertEquals( 'league', get_option( 'wpcm_mode' ) );
+		$this->assertEquals( 'GB', get_option( 'wpcm_default_country' ) );
+
+		$this->test_options = array_merge( $this->test_options, array_keys( $import_data ) );
+	}
+
+	public function test_import_rejects_non_wpcm_keys() {
+		$import_data = array(
+			'wpcm_sport'   => 'soccer',
+			'blogname'     => 'Hacked Site',
+			'admin_email'  => 'evil@example.com',
+		);
+
+		WPCM_Settings_Tools::import_settings( $import_data );
+
+		$this->assertEquals( 'soccer', get_option( 'wpcm_sport' ) );
+		$this->assertNotEquals( 'Hacked Site', get_option( 'blogname' ) );
+		$this->assertNotEquals( 'evil@example.com', get_option( 'admin_email' ) );
+
+		$this->test_options[] = 'wpcm_sport';
+	}
+
+	public function test_import_rejects_internal_options() {
+		$original_version = get_option( 'wpclubmanager_version' );
+
+		$import_data = array(
+			'wpclubmanager_version'   => '9.9.9',
+			'wpclubmanager_installed' => '0',
+		);
+
+		WPCM_Settings_Tools::import_settings( $import_data );
+
+		$this->assertEquals( $original_version, get_option( 'wpclubmanager_version' ) );
+	}
+
+	public function test_import_handles_array_values() {
+		$import_data = array(
+			'wpcm_standings_columns_display' => array( 'p', 'w', 'd', 'l', 'pts' ),
+		);
+
+		$result = WPCM_Settings_Tools::import_settings( $import_data );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( array( 'p', 'w', 'd', 'l', 'pts' ), get_option( 'wpcm_standings_columns_display' ) );
+
+		$this->test_options[] = 'wpcm_standings_columns_display';
+	}
+
+	public function test_import_returns_false_for_empty_data() {
+		$result = WPCM_Settings_Tools::import_settings( array() );
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------
+	// Round-trip
+	// -------------------------------------------------------------------
+
+	public function test_export_then_import_preserves_settings() {
+		$this->set_option( 'wpcm_sport', 'hockey' );
+		$this->set_option( 'wpcm_mode', 'club' );
+		$this->set_option( 'wpcm_standings_win_points', '4' );
+		$this->set_option( 'wpcm_map_select', 'osm' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+
+		// Change settings.
+		update_option( 'wpcm_sport', 'soccer' );
+		update_option( 'wpcm_mode', 'league' );
+		update_option( 'wpcm_standings_win_points', '3' );
+		update_option( 'wpcm_map_select', 'google' );
+
+		// Import the original export.
+		WPCM_Settings_Tools::import_settings( $exported );
+
+		$this->assertEquals( 'hockey', get_option( 'wpcm_sport' ) );
+		$this->assertEquals( 'club', get_option( 'wpcm_mode' ) );
+		$this->assertEquals( '4', get_option( 'wpcm_standings_win_points' ) );
+		$this->assertEquals( 'osm', get_option( 'wpcm_map_select' ) );
+	}
+
+	// -------------------------------------------------------------------
+	// JSON encoding
+	// -------------------------------------------------------------------
+
+	public function test_export_data_is_json_encodable() {
+		$this->set_option( 'wpcm_sport', 'soccer' );
+		$this->set_option( 'wpcm_mode', 'club' );
+
+		$exported = WPCM_Settings_Tools::get_export_data();
+		$json     = wp_json_encode( $exported );
+
+		$this->assertNotFalse( $json );
+
+		$decoded = json_decode( $json, true );
+		$this->assertEquals( $exported, $decoded );
+	}
+
+	public function test_validate_import_json_rejects_invalid_json() {
+		$result = WPCM_Settings_Tools::validate_import_json( 'not valid json{{{' );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	public function test_validate_import_json_rejects_non_object_json() {
+		$result = WPCM_Settings_Tools::validate_import_json( '"just a string"' );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	public function test_validate_import_json_accepts_valid_settings() {
+		$json = wp_json_encode( array( 'wpcm_sport' => 'soccer' ) );
+
+		$result = WPCM_Settings_Tools::validate_import_json( $json );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'wpcm_sport', $result );
+	}
+}

--- a/wpclubmanager.php
+++ b/wpclubmanager.php
@@ -6,7 +6,7 @@
  * Author: WP Club Manager
  * Author URI: https://wpclubmanager.com
  * Requires PHP: 7.4
- * Version: 2.3.3
+ * Version: 2.4.0
  * Text Domain: wp-club-manager
  * Domain Path: /languages/
  * License: GPLv3
@@ -27,7 +27,7 @@ if ( ! function_exists( 'WPCM' ) ) :
 	function WPCM() {
 		require_once __DIR__ . '/includes/class-wp-club-manager.php';
 
-		return WP_Club_Manager::instance( __FILE__, '2.3.3' );
+		return WP_Club_Manager::instance( __FILE__, '2.4.0' );
 	}
 endif;
 


### PR DESCRIPTION
## Summary

Release v2.4.0 — merges develop into master with version bump and changelog.

### Changes included

**Features:**
- Recreate shortcodes as Gutenberg blocks
- Head-to-head sorting in league tables
- Support individual/non-team sports
- Option to remove link on player photo in gallery
- Include all settings in export/import

**Additions:**
- Match calendar view with iCal support

**Fixes:**
- Match import not finding existing competitions/teams
- 404 error on league table pages
- Accented characters broken in permalinks
- Scheduled matches returning 404 on frontend
- Dashboard widget PHP warnings and stats query

## Test plan

- [ ] Verify version shows 2.4.0 in plugin header
- [ ] CI checks pass (PHPCS, PHPStan, WPUnit, Playwright)
- [ ] Changelog renders correctly in readme.txt